### PR TITLE
Fix beartype deprecation warnings in unit tests

### DIFF
--- a/templates/tests.py.j2
+++ b/templates/tests.py.j2
@@ -5,7 +5,7 @@ from bearboto3.{{ service }} import (
     {% endfor %}
 )
 from beartype import beartype
-from beartype.roar import (BeartypeCallHintPepParamException,
+from beartype.roar import (BeartypeCallHintParamViolation,
                            BeartypeCallHintReturnViolation,
                            BeartypeDecorHintPep484585Exception)
 
@@ -25,7 +25,7 @@ def test_{{ item['snake_name'] }}_arg_pass({{ item['fixture_name'] }}):
 
 
 def test_{{ item['snake_name'] }}_arg_fail({{ item['fail_fixture_name'] }}):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: {{ item['stub_class'] }}):

--- a/templates/tests.py.j2
+++ b/templates/tests.py.j2
@@ -6,7 +6,7 @@ from bearboto3.{{ service }} import (
 )
 from beartype import beartype
 from beartype.roar import (BeartypeCallHintPepParamException,
-                           BeartypeCallHintPepReturnException,
+                           BeartypeCallHintReturnViolation,
                            BeartypeDecorHintPep484585Exception)
 
 {% for item in items %}
@@ -44,7 +44,7 @@ def test_{{ item['snake_name'] }}_return_pass({{ item['fixture_name'] }}):
 
 def test_{{ item['snake_name'] }}_return_fail({{ item['fail_fixture_name'] }}):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype

--- a/tests/dynamodb/test_dynamodb_clients.py
+++ b/tests/dynamodb/test_dynamodb_clients.py
@@ -5,7 +5,7 @@ from bearboto3.dynamodb import (
 )
 from beartype import beartype
 from beartype.roar import (
-    BeartypeCallHintPepParamException,
+    BeartypeCallHintParamViolation,
     BeartypeCallHintReturnViolation,
     BeartypeDecorHintPep484585Exception,
 )
@@ -25,7 +25,7 @@ def test_dynamodb_client_arg_pass(gen_dynamodb_client):
 
 
 def test_dynamodb_client_arg_fail(gen_ec2_client):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: DynamoDBClient):
@@ -68,7 +68,7 @@ def test_dynamodb_resource_arg_pass(gen_dynamodb_resource):
 
 
 def test_dynamodb_resource_arg_fail(gen_ec2_resource):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: DynamoDBServiceResource):

--- a/tests/dynamodb/test_dynamodb_clients.py
+++ b/tests/dynamodb/test_dynamodb_clients.py
@@ -6,7 +6,7 @@ from bearboto3.dynamodb import (
 from beartype import beartype
 from beartype.roar import (
     BeartypeCallHintPepParamException,
-    BeartypeCallHintPepReturnException,
+    BeartypeCallHintReturnViolation,
     BeartypeDecorHintPep484585Exception,
 )
 
@@ -44,7 +44,7 @@ def test_dynamodb_client_return_pass(gen_dynamodb_client):
 
 def test_dynamodb_client_return_fail(gen_ec2_client):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -87,7 +87,7 @@ def test_dynamodb_resource_return_pass(gen_dynamodb_resource):
 
 def test_dynamodb_resource_return_fail(gen_ec2_resource):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype

--- a/tests/dynamodb/test_dynamodb_collections.py
+++ b/tests/dynamodb/test_dynamodb_collections.py
@@ -3,7 +3,7 @@ from bearboto3.dynamodb import ServiceResourceTablesCollection
 from beartype import beartype
 from beartype.roar import (
     BeartypeCallHintPepParamException,
-    BeartypeCallHintPepReturnException,
+    BeartypeCallHintReturnViolation,
     BeartypeDecorHintPep484585Exception,
 )
 
@@ -40,7 +40,7 @@ def test_tables_return_pass(gen_service_resource_tables_collection):
 
 def test_tables_return_fail(gen_service_resource_buckets_collection):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype

--- a/tests/dynamodb/test_dynamodb_collections.py
+++ b/tests/dynamodb/test_dynamodb_collections.py
@@ -2,7 +2,7 @@ import pytest
 from bearboto3.dynamodb import ServiceResourceTablesCollection
 from beartype import beartype
 from beartype.roar import (
-    BeartypeCallHintPepParamException,
+    BeartypeCallHintParamViolation,
     BeartypeCallHintReturnViolation,
     BeartypeDecorHintPep484585Exception,
 )
@@ -21,7 +21,7 @@ def test_tables_arg_pass(gen_service_resource_tables_collection):
 
 
 def test_tables_arg_fail(gen_service_resource_buckets_collection):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: ServiceResourceTablesCollection):

--- a/tests/dynamodb/test_dynamodb_paginators.py
+++ b/tests/dynamodb/test_dynamodb_paginators.py
@@ -8,7 +8,7 @@ from bearboto3.dynamodb import (
 )
 from beartype import beartype
 from beartype.roar import (
-    BeartypeCallHintPepParamException,
+    BeartypeCallHintParamViolation,
     BeartypeCallHintReturnViolation,
     BeartypeDecorHintPep484585Exception,
 )
@@ -28,7 +28,7 @@ def test_list_backups_arg_pass(gen_list_backups_paginator):
 
 
 def test_list_backups_arg_fail(gen_list_tags_of_resource_paginator):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: ListBackupsPaginator):
@@ -71,7 +71,7 @@ def test_list_tables_arg_pass(gen_list_tables_paginator):
 
 
 def test_list_tables_arg_fail(gen_list_backups_paginator):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: ListTablesPaginator):
@@ -114,7 +114,7 @@ def test_query_arg_pass(gen_query_paginator):
 
 
 def test_query_arg_fail(gen_scan_paginator):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: QueryPaginator):
@@ -157,7 +157,7 @@ def test_scan_arg_pass(gen_scan_paginator):
 
 
 def test_scan_arg_fail(gen_query_paginator):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: ScanPaginator):
@@ -200,7 +200,7 @@ def test_list_tags_of_resource_arg_pass(gen_list_tags_of_resource_paginator):
 
 
 def test_list_tags_of_resource_arg_fail(gen_query_paginator):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: ListTagsOfResourcePaginator):

--- a/tests/dynamodb/test_dynamodb_paginators.py
+++ b/tests/dynamodb/test_dynamodb_paginators.py
@@ -9,7 +9,7 @@ from bearboto3.dynamodb import (
 from beartype import beartype
 from beartype.roar import (
     BeartypeCallHintPepParamException,
-    BeartypeCallHintPepReturnException,
+    BeartypeCallHintReturnViolation,
     BeartypeDecorHintPep484585Exception,
 )
 
@@ -47,7 +47,7 @@ def test_list_backups_return_pass(gen_list_backups_paginator):
 
 def test_list_backups_return_fail(gen_list_tags_of_resource_paginator):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -90,7 +90,7 @@ def test_list_tables_return_pass(gen_list_tables_paginator):
 
 def test_list_tables_return_fail(gen_list_backups_paginator):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -133,7 +133,7 @@ def test_query_return_pass(gen_query_paginator):
 
 def test_query_return_fail(gen_scan_paginator):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -176,7 +176,7 @@ def test_scan_return_pass(gen_scan_paginator):
 
 def test_scan_return_fail(gen_query_paginator):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -219,7 +219,7 @@ def test_list_tags_of_resource_return_pass(gen_list_tags_of_resource_paginator):
 
 def test_list_tags_of_resource_return_fail(gen_query_paginator):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype

--- a/tests/dynamodb/test_dynamodb_resources.py
+++ b/tests/dynamodb/test_dynamodb_resources.py
@@ -2,7 +2,7 @@ import pytest
 from bearboto3.dynamodb import Table
 from beartype import beartype
 from beartype.roar import (
-    BeartypeCallHintPepParamException,
+    BeartypeCallHintParamViolation,
     BeartypeCallHintReturnViolation,
     BeartypeDecorHintPep484585Exception,
 )
@@ -21,7 +21,7 @@ def test_table_arg_pass(gen_table):
 
 
 def test_table_arg_fail(gen_bucket):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: Table):

--- a/tests/dynamodb/test_dynamodb_resources.py
+++ b/tests/dynamodb/test_dynamodb_resources.py
@@ -3,7 +3,7 @@ from bearboto3.dynamodb import Table
 from beartype import beartype
 from beartype.roar import (
     BeartypeCallHintPepParamException,
-    BeartypeCallHintPepReturnException,
+    BeartypeCallHintReturnViolation,
     BeartypeDecorHintPep484585Exception,
 )
 
@@ -40,7 +40,7 @@ def test_table_return_pass(gen_table):
 
 def test_table_return_fail(gen_bucket):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype

--- a/tests/dynamodb/test_dynamodb_waiters.py
+++ b/tests/dynamodb/test_dynamodb_waiters.py
@@ -6,7 +6,7 @@ from bearboto3.dynamodb import (
 from beartype import beartype
 from beartype.roar import (
     BeartypeCallHintPepParamException,
-    BeartypeCallHintPepReturnException,
+    BeartypeCallHintReturnViolation,
     BeartypeDecorHintPep484585Exception,
 )
 
@@ -44,7 +44,7 @@ def test_table_exists_return_pass(gen_table_exists_waiter):
 
 def test_table_exists_return_fail(gen_table_not_exists_waiter):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -87,7 +87,7 @@ def test_table_not_exists_return_pass(gen_table_not_exists_waiter):
 
 def test_table_not_exists_return_fail(gen_table_exists_waiter):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype

--- a/tests/dynamodb/test_dynamodb_waiters.py
+++ b/tests/dynamodb/test_dynamodb_waiters.py
@@ -5,7 +5,7 @@ from bearboto3.dynamodb import (
 )
 from beartype import beartype
 from beartype.roar import (
-    BeartypeCallHintPepParamException,
+    BeartypeCallHintParamViolation,
     BeartypeCallHintReturnViolation,
     BeartypeDecorHintPep484585Exception,
 )
@@ -25,7 +25,7 @@ def test_table_exists_arg_pass(gen_table_exists_waiter):
 
 
 def test_table_exists_arg_fail(gen_table_not_exists_waiter):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: TableExistsWaiter):
@@ -68,7 +68,7 @@ def test_table_not_exists_arg_pass(gen_table_not_exists_waiter):
 
 
 def test_table_not_exists_arg_fail(gen_table_exists_waiter):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: TableNotExistsWaiter):

--- a/tests/ec2/test_ec2_clients.py
+++ b/tests/ec2/test_ec2_clients.py
@@ -6,7 +6,7 @@ from bearboto3.ec2 import (
 from beartype import beartype
 from beartype.roar import (
     BeartypeCallHintPepParamException,
-    BeartypeCallHintPepReturnException,
+    BeartypeCallHintReturnViolation,
     BeartypeDecorHintPep484585Exception,
 )
 
@@ -44,7 +44,7 @@ def test_ec2_client_return_pass(gen_ec2_client):
 
 def test_ec2_client_return_fail(gen_s3_client):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -87,7 +87,7 @@ def test_ec2_resource_return_pass(gen_ec2_resource):
 
 def test_ec2_resource_return_fail(gen_s3_resource):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype

--- a/tests/ec2/test_ec2_clients.py
+++ b/tests/ec2/test_ec2_clients.py
@@ -5,7 +5,7 @@ from bearboto3.ec2 import (
 )
 from beartype import beartype
 from beartype.roar import (
-    BeartypeCallHintPepParamException,
+    BeartypeCallHintParamViolation,
     BeartypeCallHintReturnViolation,
     BeartypeDecorHintPep484585Exception,
 )
@@ -25,7 +25,7 @@ def test_ec2_client_arg_pass(gen_ec2_client):
 
 
 def test_ec2_client_arg_fail(gen_s3_client):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: EC2Client):
@@ -68,7 +68,7 @@ def test_ec2_resource_arg_pass(gen_ec2_resource):
 
 
 def test_ec2_resource_arg_fail(gen_s3_resource):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: EC2ServiceResource):

--- a/tests/ec2/test_ec2_collections.py
+++ b/tests/ec2/test_ec2_collections.py
@@ -36,7 +36,7 @@ from bearboto3.ec2 import (
 from beartype import beartype
 from beartype.roar import (
     BeartypeCallHintPepParamException,
-    BeartypeCallHintPepReturnException,
+    BeartypeCallHintReturnViolation,
     BeartypeDecorHintPep484585Exception,
 )
 
@@ -76,7 +76,7 @@ def test_classic_addresses_return_pass(
 
 def test_classic_addresses_return_fail(gen_service_resource_network_acls_collection):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -125,7 +125,7 @@ def test_dhcp_options_sets_return_fail(
     gen_vpc_accepted_vpc_peering_connections_collection,
 ):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -168,7 +168,7 @@ def test_images_return_pass(gen_service_resource_images_collection):
 
 def test_images_return_fail(gen_service_resource_network_acls_collection):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -211,7 +211,7 @@ def test_instances_return_pass(gen_service_resource_instances_collection):
 
 def test_instances_return_fail(gen_subnet_instances_collection):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -258,7 +258,7 @@ def test_internet_gateways_return_fail(
     gen_service_resource_dhcp_options_sets_collection,
 ):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -301,7 +301,7 @@ def test_key_pairs_return_pass(gen_service_resource_key_pairs_collection):
 
 def test_key_pairs_return_fail(gen_placement_group_instances_collection):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -344,7 +344,7 @@ def test_network_acls_return_pass(gen_service_resource_network_acls_collection):
 
 def test_network_acls_return_fail(gen_vpc_internet_gateways_collection):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -391,7 +391,7 @@ def test_network_interfaces_return_pass(
 
 def test_network_interfaces_return_fail(gen_service_resource_volumes_collection):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -434,7 +434,7 @@ def test_placement_groups_return_pass(gen_service_resource_placement_groups_coll
 
 def test_placement_groups_return_fail(gen_service_resource_route_tables_collection):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -479,7 +479,7 @@ def test_route_tables_return_fail(
     gen_service_resource_vpc_peering_connections_collection,
 ):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -522,7 +522,7 @@ def test_security_groups_return_pass(gen_service_resource_security_groups_collec
 
 def test_security_groups_return_fail(gen_service_resource_images_collection):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -565,7 +565,7 @@ def test_snapshots_return_pass(gen_service_resource_snapshots_collection):
 
 def test_snapshots_return_fail(gen_service_resource_route_tables_collection):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -608,7 +608,7 @@ def test_subnets_return_pass(gen_service_resource_subnets_collection):
 
 def test_subnets_return_fail(gen_service_resource_snapshots_collection):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -651,7 +651,7 @@ def test_volumes_return_pass(gen_service_resource_volumes_collection):
 
 def test_volumes_return_fail(gen_vpc_accepted_vpc_peering_connections_collection):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -694,7 +694,7 @@ def test_vpc_addresses_return_pass(gen_service_resource_vpc_addresses_collection
 
 def test_vpc_addresses_return_fail(gen_volume_snapshots_collection):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -741,7 +741,7 @@ def test_vpc_peering_connections_return_pass(
 
 def test_vpc_peering_connections_return_fail(gen_service_resource_snapshots_collection):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -784,7 +784,7 @@ def test_vpcs_return_pass(gen_service_resource_vpcs_collection):
 
 def test_vpcs_return_fail(gen_service_resource_images_collection):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -827,7 +827,7 @@ def test_volumes_return_pass(gen_instance_volumes_collection):
 
 def test_volumes_return_fail(gen_service_resource_network_acls_collection):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -870,7 +870,7 @@ def test_vpc_addresses_return_pass(gen_instance_vpc_addresses_collection):
 
 def test_vpc_addresses_return_fail(gen_vpc_network_acls_collection):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -913,7 +913,7 @@ def test_instances_return_pass(gen_placement_group_instances_collection):
 
 def test_instances_return_fail(gen_vpc_requested_vpc_peering_connections_collection):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -956,7 +956,7 @@ def test_instances_return_pass(gen_subnet_instances_collection):
 
 def test_instances_return_fail(gen_vpc_network_acls_collection):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -999,7 +999,7 @@ def test_network_interfaces_return_pass(gen_subnet_network_interfaces_collection
 
 def test_network_interfaces_return_fail(gen_vpc_subnets_collection):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -1042,7 +1042,7 @@ def test_snapshots_return_pass(gen_volume_snapshots_collection):
 
 def test_snapshots_return_fail(gen_vpc_subnets_collection):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -1093,7 +1093,7 @@ def test_accepted_vpc_peering_connections_return_fail(
     gen_service_resource_dhcp_options_sets_collection,
 ):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -1136,7 +1136,7 @@ def test_instances_return_pass(gen_vpc_instances_collection):
 
 def test_instances_return_fail(gen_service_resource_route_tables_collection):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -1181,7 +1181,7 @@ def test_internet_gateways_return_fail(
     gen_service_resource_internet_gateways_collection,
 ):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -1224,7 +1224,7 @@ def test_network_acls_return_pass(gen_vpc_network_acls_collection):
 
 def test_network_acls_return_fail(gen_service_resource_images_collection):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -1269,7 +1269,7 @@ def test_network_interfaces_return_fail(
     gen_service_resource_internet_gateways_collection,
 ):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -1320,7 +1320,7 @@ def test_requested_vpc_peering_connections_return_fail(
     gen_subnet_network_interfaces_collection,
 ):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -1363,7 +1363,7 @@ def test_route_tables_return_pass(gen_vpc_route_tables_collection):
 
 def test_route_tables_return_fail(gen_service_resource_dhcp_options_sets_collection):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -1406,7 +1406,7 @@ def test_security_groups_return_pass(gen_vpc_security_groups_collection):
 
 def test_security_groups_return_fail(gen_service_resource_key_pairs_collection):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -1449,7 +1449,7 @@ def test_subnets_return_pass(gen_vpc_subnets_collection):
 
 def test_subnets_return_fail(gen_vpc_route_tables_collection):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype

--- a/tests/ec2/test_ec2_collections.py
+++ b/tests/ec2/test_ec2_collections.py
@@ -35,7 +35,7 @@ from bearboto3.ec2 import (
 )
 from beartype import beartype
 from beartype.roar import (
-    BeartypeCallHintPepParamException,
+    BeartypeCallHintParamViolation,
     BeartypeCallHintReturnViolation,
     BeartypeDecorHintPep484585Exception,
 )
@@ -55,7 +55,7 @@ def test_classic_addresses_arg_pass(gen_service_resource_classic_addresses_colle
 
 
 def test_classic_addresses_arg_fail(gen_service_resource_network_acls_collection):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: ServiceResourceClassicAddressesCollection):
@@ -102,7 +102,7 @@ def test_dhcp_options_sets_arg_pass(gen_service_resource_dhcp_options_sets_colle
 def test_dhcp_options_sets_arg_fail(
     gen_vpc_accepted_vpc_peering_connections_collection,
 ):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: ServiceResourceDhcpOptionsSetsCollection):
@@ -149,7 +149,7 @@ def test_images_arg_pass(gen_service_resource_images_collection):
 
 
 def test_images_arg_fail(gen_service_resource_network_acls_collection):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: ServiceResourceImagesCollection):
@@ -192,7 +192,7 @@ def test_instances_arg_pass(gen_service_resource_instances_collection):
 
 
 def test_instances_arg_fail(gen_subnet_instances_collection):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: ServiceResourceInstancesCollection):
@@ -235,7 +235,7 @@ def test_internet_gateways_arg_pass(gen_service_resource_internet_gateways_colle
 
 
 def test_internet_gateways_arg_fail(gen_service_resource_dhcp_options_sets_collection):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: ServiceResourceInternetGatewaysCollection):
@@ -282,7 +282,7 @@ def test_key_pairs_arg_pass(gen_service_resource_key_pairs_collection):
 
 
 def test_key_pairs_arg_fail(gen_placement_group_instances_collection):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: ServiceResourceKeyPairsCollection):
@@ -325,7 +325,7 @@ def test_network_acls_arg_pass(gen_service_resource_network_acls_collection):
 
 
 def test_network_acls_arg_fail(gen_vpc_internet_gateways_collection):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: ServiceResourceNetworkAclsCollection):
@@ -370,7 +370,7 @@ def test_network_interfaces_arg_pass(
 
 
 def test_network_interfaces_arg_fail(gen_service_resource_volumes_collection):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: ServiceResourceNetworkInterfacesCollection):
@@ -415,7 +415,7 @@ def test_placement_groups_arg_pass(gen_service_resource_placement_groups_collect
 
 
 def test_placement_groups_arg_fail(gen_service_resource_route_tables_collection):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: ServiceResourcePlacementGroupsCollection):
@@ -458,7 +458,7 @@ def test_route_tables_arg_pass(gen_service_resource_route_tables_collection):
 
 
 def test_route_tables_arg_fail(gen_service_resource_vpc_peering_connections_collection):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: ServiceResourceRouteTablesCollection):
@@ -503,7 +503,7 @@ def test_security_groups_arg_pass(gen_service_resource_security_groups_collectio
 
 
 def test_security_groups_arg_fail(gen_service_resource_images_collection):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: ServiceResourceSecurityGroupsCollection):
@@ -546,7 +546,7 @@ def test_snapshots_arg_pass(gen_service_resource_snapshots_collection):
 
 
 def test_snapshots_arg_fail(gen_service_resource_route_tables_collection):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: ServiceResourceSnapshotsCollection):
@@ -589,7 +589,7 @@ def test_subnets_arg_pass(gen_service_resource_subnets_collection):
 
 
 def test_subnets_arg_fail(gen_service_resource_snapshots_collection):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: ServiceResourceSubnetsCollection):
@@ -632,7 +632,7 @@ def test_volumes_arg_pass(gen_service_resource_volumes_collection):
 
 
 def test_volumes_arg_fail(gen_vpc_accepted_vpc_peering_connections_collection):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: ServiceResourceVolumesCollection):
@@ -675,7 +675,7 @@ def test_vpc_addresses_arg_pass(gen_service_resource_vpc_addresses_collection):
 
 
 def test_vpc_addresses_arg_fail(gen_volume_snapshots_collection):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: ServiceResourceVpcAddressesCollection):
@@ -720,7 +720,7 @@ def test_vpc_peering_connections_arg_pass(
 
 
 def test_vpc_peering_connections_arg_fail(gen_service_resource_snapshots_collection):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: ServiceResourceVpcPeeringConnectionsCollection):
@@ -765,7 +765,7 @@ def test_vpcs_arg_pass(gen_service_resource_vpcs_collection):
 
 
 def test_vpcs_arg_fail(gen_service_resource_images_collection):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: ServiceResourceVpcsCollection):
@@ -808,7 +808,7 @@ def test_volumes_arg_pass(gen_instance_volumes_collection):
 
 
 def test_volumes_arg_fail(gen_service_resource_network_acls_collection):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: InstanceVolumesCollection):
@@ -851,7 +851,7 @@ def test_vpc_addresses_arg_pass(gen_instance_vpc_addresses_collection):
 
 
 def test_vpc_addresses_arg_fail(gen_vpc_network_acls_collection):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: InstanceVpcAddressesCollection):
@@ -894,7 +894,7 @@ def test_instances_arg_pass(gen_placement_group_instances_collection):
 
 
 def test_instances_arg_fail(gen_vpc_requested_vpc_peering_connections_collection):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: PlacementGroupInstancesCollection):
@@ -937,7 +937,7 @@ def test_instances_arg_pass(gen_subnet_instances_collection):
 
 
 def test_instances_arg_fail(gen_vpc_network_acls_collection):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: SubnetInstancesCollection):
@@ -980,7 +980,7 @@ def test_network_interfaces_arg_pass(gen_subnet_network_interfaces_collection):
 
 
 def test_network_interfaces_arg_fail(gen_vpc_subnets_collection):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: SubnetNetworkInterfacesCollection):
@@ -1023,7 +1023,7 @@ def test_snapshots_arg_pass(gen_volume_snapshots_collection):
 
 
 def test_snapshots_arg_fail(gen_vpc_subnets_collection):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: VolumeSnapshotsCollection):
@@ -1070,7 +1070,7 @@ def test_accepted_vpc_peering_connections_arg_pass(
 def test_accepted_vpc_peering_connections_arg_fail(
     gen_service_resource_dhcp_options_sets_collection,
 ):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: VpcAcceptedVpcPeeringConnectionsCollection):
@@ -1117,7 +1117,7 @@ def test_instances_arg_pass(gen_vpc_instances_collection):
 
 
 def test_instances_arg_fail(gen_service_resource_route_tables_collection):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: VpcInstancesCollection):
@@ -1160,7 +1160,7 @@ def test_internet_gateways_arg_pass(gen_vpc_internet_gateways_collection):
 
 
 def test_internet_gateways_arg_fail(gen_service_resource_internet_gateways_collection):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: VpcInternetGatewaysCollection):
@@ -1205,7 +1205,7 @@ def test_network_acls_arg_pass(gen_vpc_network_acls_collection):
 
 
 def test_network_acls_arg_fail(gen_service_resource_images_collection):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: VpcNetworkAclsCollection):
@@ -1248,7 +1248,7 @@ def test_network_interfaces_arg_pass(gen_vpc_network_interfaces_collection):
 
 
 def test_network_interfaces_arg_fail(gen_service_resource_internet_gateways_collection):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: VpcNetworkInterfacesCollection):
@@ -1297,7 +1297,7 @@ def test_requested_vpc_peering_connections_arg_pass(
 def test_requested_vpc_peering_connections_arg_fail(
     gen_subnet_network_interfaces_collection,
 ):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: VpcRequestedVpcPeeringConnectionsCollection):
@@ -1344,7 +1344,7 @@ def test_route_tables_arg_pass(gen_vpc_route_tables_collection):
 
 
 def test_route_tables_arg_fail(gen_service_resource_dhcp_options_sets_collection):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: VpcRouteTablesCollection):
@@ -1387,7 +1387,7 @@ def test_security_groups_arg_pass(gen_vpc_security_groups_collection):
 
 
 def test_security_groups_arg_fail(gen_service_resource_key_pairs_collection):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: VpcSecurityGroupsCollection):
@@ -1430,7 +1430,7 @@ def test_subnets_arg_pass(gen_vpc_subnets_collection):
 
 
 def test_subnets_arg_fail(gen_vpc_route_tables_collection):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: VpcSubnetsCollection):

--- a/tests/ec2/test_ec2_paginators.py
+++ b/tests/ec2/test_ec2_paginators.py
@@ -110,7 +110,7 @@ from bearboto3.ec2 import (
 )
 from beartype import beartype
 from beartype.roar import (
-    BeartypeCallHintPepParamException,
+    BeartypeCallHintParamViolation,
     BeartypeCallHintReturnViolation,
     BeartypeDecorHintPep484585Exception,
 )
@@ -132,7 +132,7 @@ def test_describe_route_tables_arg_pass(gen_describe_route_tables_paginator):
 def test_describe_route_tables_arg_fail(
     gen_describe_transit_gateway_attachments_paginator,
 ):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: DescribeRouteTablesPaginator):
@@ -181,7 +181,7 @@ def test_describe_iam_instance_profile_associations_arg_pass(
 def test_describe_iam_instance_profile_associations_arg_fail(
     gen_describe_vpcs_paginator,
 ):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: DescribeIamInstanceProfileAssociationsPaginator):
@@ -228,7 +228,7 @@ def test_describe_instance_status_arg_pass(gen_describe_instance_status_paginato
 
 
 def test_describe_instance_status_arg_fail(gen_search_local_gateway_routes_paginator):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: DescribeInstanceStatusPaginator):
@@ -273,7 +273,7 @@ def test_describe_instances_arg_pass(gen_describe_instances_paginator):
 
 
 def test_describe_instances_arg_fail(gen_describe_replace_root_volume_tasks_paginator):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: DescribeInstancesPaginator):
@@ -322,7 +322,7 @@ def test_describe_reserved_instances_offerings_arg_pass(
 def test_describe_reserved_instances_offerings_arg_fail(
     gen_describe_trunk_interface_associations_paginator,
 ):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: DescribeReservedInstancesOfferingsPaginator):
@@ -373,7 +373,7 @@ def test_describe_reserved_instances_modifications_arg_pass(
 def test_describe_reserved_instances_modifications_arg_fail(
     gen_describe_dhcp_options_paginator,
 ):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: DescribeReservedInstancesModificationsPaginator):
@@ -420,7 +420,7 @@ def test_describe_security_groups_arg_pass(gen_describe_security_groups_paginato
 
 
 def test_describe_security_groups_arg_fail(gen_describe_spot_fleet_instances_paginator):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: DescribeSecurityGroupsPaginator):
@@ -465,7 +465,7 @@ def test_describe_snapshots_arg_pass(gen_describe_snapshots_paginator):
 
 
 def test_describe_snapshots_arg_fail(gen_describe_client_vpn_endpoints_paginator):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: DescribeSnapshotsPaginator):
@@ -512,7 +512,7 @@ def test_describe_spot_fleet_instances_arg_pass(
 def test_describe_spot_fleet_instances_arg_fail(
     gen_describe_security_group_rules_paginator,
 ):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: DescribeSpotFleetInstancesPaginator):
@@ -563,7 +563,7 @@ def test_describe_spot_fleet_requests_arg_pass(
 def test_describe_spot_fleet_requests_arg_fail(
     gen_describe_local_gateway_route_table_vpc_associations_paginator,
 ):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: DescribeSpotFleetRequestsPaginator):
@@ -614,7 +614,7 @@ def test_describe_spot_price_history_arg_pass(
 def test_describe_spot_price_history_arg_fail(
     gen_describe_replace_root_volume_tasks_paginator,
 ):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: DescribeSpotPriceHistoryPaginator):
@@ -661,7 +661,7 @@ def test_describe_tags_arg_pass(gen_describe_tags_paginator):
 
 
 def test_describe_tags_arg_fail(gen_describe_flow_logs_paginator):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: DescribeTagsPaginator):
@@ -704,7 +704,7 @@ def test_describe_volume_status_arg_pass(gen_describe_volume_status_paginator):
 
 
 def test_describe_volume_status_arg_fail(gen_describe_network_insights_paths_paginator):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: DescribeVolumeStatusPaginator):
@@ -749,7 +749,7 @@ def test_describe_volumes_arg_pass(gen_describe_volumes_paginator):
 
 
 def test_describe_volumes_arg_fail(gen_describe_instance_event_windows_paginator):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: DescribeVolumesPaginator):
@@ -794,7 +794,7 @@ def test_describe_nat_gateways_arg_pass(gen_describe_nat_gateways_paginator):
 def test_describe_nat_gateways_arg_fail(
     gen_describe_scheduled_instance_availability_paginator,
 ):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: DescribeNatGatewaysPaginator):
@@ -843,7 +843,7 @@ def test_describe_network_interfaces_arg_pass(
 def test_describe_network_interfaces_arg_fail(
     gen_describe_client_vpn_connections_paginator,
 ):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: DescribeNetworkInterfacesPaginator):
@@ -890,7 +890,7 @@ def test_describe_vpc_endpoints_arg_pass(gen_describe_vpc_endpoints_paginator):
 
 
 def test_describe_vpc_endpoints_arg_fail(gen_describe_byoip_cidrs_paginator):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: DescribeVpcEndpointsPaginator):
@@ -937,7 +937,7 @@ def test_describe_vpc_endpoint_services_arg_pass(
 def test_describe_vpc_endpoint_services_arg_fail(
     gen_describe_public_ipv4_pools_paginator,
 ):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: DescribeVpcEndpointServicesPaginator):
@@ -988,7 +988,7 @@ def test_describe_vpc_endpoint_connections_arg_pass(
 def test_describe_vpc_endpoint_connections_arg_fail(
     gen_describe_spot_instance_requests_paginator,
 ):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: DescribeVpcEndpointConnectionsPaginator):
@@ -1035,7 +1035,7 @@ def test_describe_byoip_cidrs_arg_pass(gen_describe_byoip_cidrs_paginator):
 
 
 def test_describe_byoip_cidrs_arg_fail(gen_get_associated_ipv6_pool_cidrs_paginator):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: DescribeByoipCidrsPaginator):
@@ -1082,7 +1082,7 @@ def test_describe_capacity_reservations_arg_pass(
 def test_describe_capacity_reservations_arg_fail(
     gen_describe_transit_gateway_connects_paginator,
 ):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: DescribeCapacityReservationsPaginator):
@@ -1133,7 +1133,7 @@ def test_describe_classic_link_instances_arg_pass(
 def test_describe_classic_link_instances_arg_fail(
     gen_describe_vpc_endpoint_service_permissions_paginator,
 ):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: DescribeClassicLinkInstancesPaginator):
@@ -1184,7 +1184,7 @@ def test_describe_client_vpn_authorization_rules_arg_pass(
 def test_describe_client_vpn_authorization_rules_arg_fail(
     gen_describe_fpga_images_paginator,
 ):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: DescribeClientVpnAuthorizationRulesPaginator):
@@ -1233,7 +1233,7 @@ def test_describe_client_vpn_connections_arg_pass(
 
 
 def test_describe_client_vpn_connections_arg_fail(gen_describe_route_tables_paginator):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: DescribeClientVpnConnectionsPaginator):
@@ -1282,7 +1282,7 @@ def test_describe_client_vpn_endpoints_arg_pass(
 
 
 def test_describe_client_vpn_endpoints_arg_fail(gen_describe_byoip_cidrs_paginator):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: DescribeClientVpnEndpointsPaginator):
@@ -1327,7 +1327,7 @@ def test_describe_client_vpn_routes_arg_pass(gen_describe_client_vpn_routes_pagi
 
 
 def test_describe_client_vpn_routes_arg_fail(gen_describe_snapshots_paginator):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: DescribeClientVpnRoutesPaginator):
@@ -1374,7 +1374,7 @@ def test_describe_client_vpn_target_networks_arg_pass(
 
 
 def test_describe_client_vpn_target_networks_arg_fail(gen_describe_subnets_paginator):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: DescribeClientVpnTargetNetworksPaginator):
@@ -1425,7 +1425,7 @@ def test_describe_egress_only_internet_gateways_arg_pass(
 def test_describe_egress_only_internet_gateways_arg_fail(
     gen_describe_traffic_mirror_targets_paginator,
 ):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: DescribeEgressOnlyInternetGatewaysPaginator):
@@ -1472,7 +1472,7 @@ def test_describe_fleets_arg_pass(gen_describe_fleets_paginator):
 
 
 def test_describe_fleets_arg_fail(gen_describe_security_groups_paginator):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: DescribeFleetsPaginator):
@@ -1515,7 +1515,7 @@ def test_describe_flow_logs_arg_pass(gen_describe_flow_logs_paginator):
 
 
 def test_describe_flow_logs_arg_fail(gen_describe_coip_pools_paginator):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: DescribeFlowLogsPaginator):
@@ -1558,7 +1558,7 @@ def test_describe_fpga_images_arg_pass(gen_describe_fpga_images_paginator):
 
 
 def test_describe_fpga_images_arg_fail(gen_describe_moving_addresses_paginator):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: DescribeFpgaImagesPaginator):
@@ -1605,7 +1605,7 @@ def test_describe_host_reservation_offerings_arg_pass(
 def test_describe_host_reservation_offerings_arg_fail(
     gen_describe_client_vpn_target_networks_paginator,
 ):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: DescribeHostReservationOfferingsPaginator):
@@ -1652,7 +1652,7 @@ def test_describe_host_reservations_arg_pass(gen_describe_host_reservations_pagi
 
 
 def test_describe_host_reservations_arg_fail(gen_describe_volume_status_paginator):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: DescribeHostReservationsPaginator):
@@ -1697,7 +1697,7 @@ def test_describe_hosts_arg_pass(gen_describe_hosts_paginator):
 
 
 def test_describe_hosts_arg_fail(gen_describe_store_image_tasks_paginator):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: DescribeHostsPaginator):
@@ -1742,7 +1742,7 @@ def test_describe_import_image_tasks_arg_pass(
 
 
 def test_describe_import_image_tasks_arg_fail(gen_describe_tags_paginator):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: DescribeImportImageTasksPaginator):
@@ -1791,7 +1791,7 @@ def test_describe_import_snapshot_tasks_arg_pass(
 def test_describe_import_snapshot_tasks_arg_fail(
     gen_describe_addresses_attribute_paginator,
 ):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: DescribeImportSnapshotTasksPaginator):
@@ -1842,7 +1842,7 @@ def test_describe_instance_credit_specifications_arg_pass(
 def test_describe_instance_credit_specifications_arg_fail(
     gen_describe_network_interfaces_paginator,
 ):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: DescribeInstanceCreditSpecificationsPaginator):
@@ -1893,7 +1893,7 @@ def test_describe_launch_template_versions_arg_pass(
 def test_describe_launch_template_versions_arg_fail(
     gen_describe_spot_instance_requests_paginator,
 ):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: DescribeLaunchTemplateVersionsPaginator):
@@ -1940,7 +1940,7 @@ def test_describe_launch_templates_arg_pass(gen_describe_launch_templates_pagina
 
 
 def test_describe_launch_templates_arg_fail(gen_describe_coip_pools_paginator):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: DescribeLaunchTemplatesPaginator):
@@ -1983,7 +1983,7 @@ def test_describe_moving_addresses_arg_pass(gen_describe_moving_addresses_pagina
 
 
 def test_describe_moving_addresses_arg_fail(gen_describe_fpga_images_paginator):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: DescribeMovingAddressesPaginator):
@@ -2030,7 +2030,7 @@ def test_describe_network_interface_permissions_arg_pass(
 def test_describe_network_interface_permissions_arg_fail(
     gen_describe_network_insights_paths_paginator,
 ):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: DescribeNetworkInterfacePermissionsPaginator):
@@ -2077,7 +2077,7 @@ def test_describe_prefix_lists_arg_pass(gen_describe_prefix_lists_paginator):
 
 
 def test_describe_prefix_lists_arg_fail(gen_describe_volumes_modifications_paginator):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: DescribePrefixListsPaginator):
@@ -2126,7 +2126,7 @@ def test_describe_principal_id_format_arg_pass(
 def test_describe_principal_id_format_arg_fail(
     gen_get_associated_ipv6_pool_cidrs_paginator,
 ):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: DescribePrincipalIdFormatPaginator):
@@ -2175,7 +2175,7 @@ def test_describe_public_ipv4_pools_arg_pass(gen_describe_public_ipv4_pools_pagi
 def test_describe_public_ipv4_pools_arg_fail(
     gen_describe_local_gateway_virtual_interfaces_paginator,
 ):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: DescribePublicIpv4PoolsPaginator):
@@ -2226,7 +2226,7 @@ def test_describe_scheduled_instance_availability_arg_pass(
 def test_describe_scheduled_instance_availability_arg_fail(
     gen_get_vpn_connection_device_types_paginator,
 ):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: DescribeScheduledInstanceAvailabilityPaginator):
@@ -2275,7 +2275,7 @@ def test_describe_scheduled_instances_arg_pass(
 
 
 def test_describe_scheduled_instances_arg_fail(gen_describe_instance_status_paginator):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: DescribeScheduledInstancesPaginator):
@@ -2326,7 +2326,7 @@ def test_describe_stale_security_groups_arg_pass(
 def test_describe_stale_security_groups_arg_fail(
     gen_get_associated_ipv6_pool_cidrs_paginator,
 ):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: DescribeStaleSecurityGroupsPaginator):
@@ -2377,7 +2377,7 @@ def test_describe_transit_gateway_attachments_arg_pass(
 def test_describe_transit_gateway_attachments_arg_fail(
     gen_describe_local_gateway_route_tables_paginator,
 ):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: DescribeTransitGatewayAttachmentsPaginator):
@@ -2428,7 +2428,7 @@ def test_describe_transit_gateway_route_tables_arg_pass(
 def test_describe_transit_gateway_route_tables_arg_fail(
     gen_describe_launch_templates_paginator,
 ):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: DescribeTransitGatewayRouteTablesPaginator):
@@ -2479,7 +2479,7 @@ def test_describe_transit_gateway_vpc_attachments_arg_pass(
 def test_describe_transit_gateway_vpc_attachments_arg_fail(
     gen_get_instance_types_from_instance_requirements_paginator,
 ):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: DescribeTransitGatewayVpcAttachmentsPaginator):
@@ -2526,7 +2526,7 @@ def test_describe_transit_gateways_arg_pass(gen_describe_transit_gateways_pagina
 
 
 def test_describe_transit_gateways_arg_fail(gen_describe_route_tables_paginator):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: DescribeTransitGatewaysPaginator):
@@ -2571,7 +2571,7 @@ def test_describe_volumes_modifications_arg_pass(
 
 
 def test_describe_volumes_modifications_arg_fail(gen_describe_instance_types_paginator):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: DescribeVolumesModificationsPaginator):
@@ -2622,7 +2622,7 @@ def test_describe_vpc_classic_link_dns_support_arg_pass(
 def test_describe_vpc_classic_link_dns_support_arg_fail(
     gen_get_transit_gateway_multicast_domain_associations_paginator,
 ):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: DescribeVpcClassicLinkDnsSupportPaginator):
@@ -2673,7 +2673,7 @@ def test_describe_vpc_endpoint_connection_notifications_arg_pass(
 def test_describe_vpc_endpoint_connection_notifications_arg_fail(
     gen_describe_launch_templates_paginator,
 ):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: DescribeVpcEndpointConnectionNotificationsPaginator):
@@ -2724,7 +2724,7 @@ def test_describe_vpc_endpoint_service_configurations_arg_pass(
 def test_describe_vpc_endpoint_service_configurations_arg_fail(
     gen_describe_vpcs_paginator,
 ):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: DescribeVpcEndpointServiceConfigurationsPaginator):
@@ -2775,7 +2775,7 @@ def test_describe_vpc_endpoint_service_permissions_arg_pass(
 def test_describe_vpc_endpoint_service_permissions_arg_fail(
     gen_describe_vpc_peering_connections_paginator,
 ):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: DescribeVpcEndpointServicePermissionsPaginator):
@@ -2826,7 +2826,7 @@ def test_describe_vpc_peering_connections_arg_pass(
 def test_describe_vpc_peering_connections_arg_fail(
     gen_describe_network_insights_paths_paginator,
 ):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: DescribeVpcPeeringConnectionsPaginator):
@@ -2877,7 +2877,7 @@ def test_get_transit_gateway_attachment_propagations_arg_pass(
 def test_get_transit_gateway_attachment_propagations_arg_fail(
     gen_get_managed_prefix_list_entries_paginator,
 ):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: GetTransitGatewayAttachmentPropagationsPaginator):
@@ -2928,7 +2928,7 @@ def test_get_transit_gateway_route_table_associations_arg_pass(
 def test_get_transit_gateway_route_table_associations_arg_fail(
     gen_describe_classic_link_instances_paginator,
 ):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: GetTransitGatewayRouteTableAssociationsPaginator):
@@ -2979,7 +2979,7 @@ def test_get_transit_gateway_route_table_propagations_arg_pass(
 def test_get_transit_gateway_route_table_propagations_arg_fail(
     gen_describe_ipv6_pools_paginator,
 ):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: GetTransitGatewayRouteTablePropagationsPaginator):
@@ -3028,7 +3028,7 @@ def test_describe_internet_gateways_arg_pass(gen_describe_internet_gateways_pagi
 def test_describe_internet_gateways_arg_fail(
     gen_describe_network_insights_analyses_paginator,
 ):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: DescribeInternetGatewaysPaginator):
@@ -3075,7 +3075,7 @@ def test_describe_network_acls_arg_pass(gen_describe_network_acls_paginator):
 
 
 def test_describe_network_acls_arg_fail(gen_describe_instance_type_offerings_paginator):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: DescribeNetworkAclsPaginator):
@@ -3120,7 +3120,7 @@ def test_describe_vpcs_arg_pass(gen_describe_vpcs_paginator):
 
 
 def test_describe_vpcs_arg_fail(gen_describe_fleets_paginator):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: DescribeVpcsPaginator):
@@ -3167,7 +3167,7 @@ def test_describe_spot_instance_requests_arg_pass(
 def test_describe_spot_instance_requests_arg_fail(
     gen_describe_vpc_endpoint_service_permissions_paginator,
 ):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: DescribeSpotInstanceRequestsPaginator):
@@ -3216,7 +3216,7 @@ def test_describe_dhcp_options_arg_pass(gen_describe_dhcp_options_paginator):
 def test_describe_dhcp_options_arg_fail(
     gen_get_transit_gateway_prefix_list_references_paginator,
 ):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: DescribeDhcpOptionsPaginator):
@@ -3263,7 +3263,7 @@ def test_describe_subnets_arg_pass(gen_describe_subnets_paginator):
 def test_describe_subnets_arg_fail(
     gen_describe_egress_only_internet_gateways_paginator,
 ):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: DescribeSubnetsPaginator):
@@ -3312,7 +3312,7 @@ def test_describe_traffic_mirror_filters_arg_pass(
 def test_describe_traffic_mirror_filters_arg_fail(
     gen_describe_transit_gateway_vpc_attachments_paginator,
 ):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: DescribeTrafficMirrorFiltersPaginator):
@@ -3363,7 +3363,7 @@ def test_describe_traffic_mirror_sessions_arg_pass(
 def test_describe_traffic_mirror_sessions_arg_fail(
     gen_describe_client_vpn_connections_paginator,
 ):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: DescribeTrafficMirrorSessionsPaginator):
@@ -3414,7 +3414,7 @@ def test_describe_traffic_mirror_targets_arg_pass(
 def test_describe_traffic_mirror_targets_arg_fail(
     gen_describe_vpc_endpoint_services_paginator,
 ):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: DescribeTrafficMirrorTargetsPaginator):
@@ -3465,7 +3465,7 @@ def test_describe_export_image_tasks_arg_pass(
 def test_describe_export_image_tasks_arg_fail(
     gen_get_managed_prefix_list_associations_paginator,
 ):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: DescribeExportImageTasksPaginator):
@@ -3516,7 +3516,7 @@ def test_describe_fast_snapshot_restores_arg_pass(
 def test_describe_fast_snapshot_restores_arg_fail(
     gen_describe_transit_gateway_multicast_domains_paginator,
 ):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: DescribeFastSnapshotRestoresPaginator):
@@ -3563,7 +3563,7 @@ def test_describe_ipv6_pools_arg_pass(gen_describe_ipv6_pools_paginator):
 
 
 def test_describe_ipv6_pools_arg_fail(gen_describe_launch_template_versions_paginator):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: DescribeIpv6PoolsPaginator):
@@ -3612,7 +3612,7 @@ def test_get_associated_ipv6_pool_cidrs_arg_pass(
 def test_get_associated_ipv6_pool_cidrs_arg_fail(
     gen_describe_spot_fleet_instances_paginator,
 ):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: GetAssociatedIpv6PoolCidrsPaginator):
@@ -3659,7 +3659,7 @@ def test_describe_coip_pools_arg_pass(gen_describe_coip_pools_paginator):
 
 
 def test_describe_coip_pools_arg_fail(gen_describe_instance_event_windows_paginator):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: DescribeCoipPoolsPaginator):
@@ -3706,7 +3706,7 @@ def test_describe_instance_type_offerings_arg_pass(
 def test_describe_instance_type_offerings_arg_fail(
     gen_describe_traffic_mirror_targets_paginator,
 ):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: DescribeInstanceTypeOfferingsPaginator):
@@ -3753,7 +3753,7 @@ def test_describe_instance_types_arg_pass(gen_describe_instance_types_paginator)
 
 
 def test_describe_instance_types_arg_fail(gen_describe_flow_logs_paginator):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: DescribeInstanceTypesPaginator):
@@ -3804,7 +3804,7 @@ def test_describe_local_gateway_route_table_virtual_interface_group_associations
 def test_describe_local_gateway_route_table_virtual_interface_group_associations_arg_fail(
     gen_describe_security_groups_paginator,
 ):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(
@@ -3857,7 +3857,7 @@ def test_describe_local_gateway_route_table_vpc_associations_arg_pass(
 def test_describe_local_gateway_route_table_vpc_associations_arg_fail(
     gen_get_managed_prefix_list_entries_paginator,
 ):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: DescribeLocalGatewayRouteTableVpcAssociationsPaginator):
@@ -3908,7 +3908,7 @@ def test_describe_local_gateway_route_tables_arg_pass(
 def test_describe_local_gateway_route_tables_arg_fail(
     gen_describe_managed_prefix_lists_paginator,
 ):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: DescribeLocalGatewayRouteTablesPaginator):
@@ -3959,7 +3959,7 @@ def test_describe_local_gateway_virtual_interface_groups_arg_pass(
 def test_describe_local_gateway_virtual_interface_groups_arg_fail(
     gen_describe_subnets_paginator,
 ):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: DescribeLocalGatewayVirtualInterfaceGroupsPaginator):
@@ -4010,7 +4010,7 @@ def test_describe_local_gateway_virtual_interfaces_arg_pass(
 def test_describe_local_gateway_virtual_interfaces_arg_fail(
     gen_describe_import_snapshot_tasks_paginator,
 ):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: DescribeLocalGatewayVirtualInterfacesPaginator):
@@ -4059,7 +4059,7 @@ def test_describe_local_gateways_arg_pass(gen_describe_local_gateways_paginator)
 def test_describe_local_gateways_arg_fail(
     gen_describe_classic_link_instances_paginator,
 ):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: DescribeLocalGatewaysPaginator):
@@ -4108,7 +4108,7 @@ def test_describe_transit_gateway_multicast_domains_arg_pass(
 def test_describe_transit_gateway_multicast_domains_arg_fail(
     gen_describe_vpc_endpoint_services_paginator,
 ):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: DescribeTransitGatewayMulticastDomainsPaginator):
@@ -4159,7 +4159,7 @@ def test_describe_transit_gateway_peering_attachments_arg_pass(
 def test_describe_transit_gateway_peering_attachments_arg_fail(
     gen_describe_export_image_tasks_paginator,
 ):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: DescribeTransitGatewayPeeringAttachmentsPaginator):
@@ -4210,7 +4210,7 @@ def test_get_transit_gateway_multicast_domain_associations_arg_pass(
 def test_get_transit_gateway_multicast_domain_associations_arg_fail(
     gen_describe_capacity_reservation_fleets_paginator,
 ):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: GetTransitGatewayMulticastDomainAssociationsPaginator):
@@ -4261,7 +4261,7 @@ def test_search_local_gateway_routes_arg_pass(
 def test_search_local_gateway_routes_arg_fail(
     gen_describe_local_gateway_route_table_virtual_interface_group_associations_paginator,
 ):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: SearchLocalGatewayRoutesPaginator):
@@ -4314,7 +4314,7 @@ def test_search_transit_gateway_multicast_groups_arg_pass(
 def test_search_transit_gateway_multicast_groups_arg_fail(
     gen_describe_subnets_paginator,
 ):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: SearchTransitGatewayMulticastGroupsPaginator):
@@ -4365,7 +4365,7 @@ def test_describe_managed_prefix_lists_arg_pass(
 def test_describe_managed_prefix_lists_arg_fail(
     gen_describe_transit_gateway_multicast_domains_paginator,
 ):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: DescribeManagedPrefixListsPaginator):
@@ -4416,7 +4416,7 @@ def test_get_managed_prefix_list_associations_arg_pass(
 def test_get_managed_prefix_list_associations_arg_fail(
     gen_get_spot_placement_scores_paginator,
 ):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: GetManagedPrefixListAssociationsPaginator):
@@ -4467,7 +4467,7 @@ def test_get_managed_prefix_list_entries_arg_pass(
 def test_get_managed_prefix_list_entries_arg_fail(
     gen_describe_host_reservation_offerings_paginator,
 ):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: GetManagedPrefixListEntriesPaginator):
@@ -4518,7 +4518,7 @@ def test_get_groups_for_capacity_reservation_arg_pass(
 def test_get_groups_for_capacity_reservation_arg_fail(
     gen_get_transit_gateway_multicast_domain_associations_paginator,
 ):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: GetGroupsForCapacityReservationPaginator):
@@ -4567,7 +4567,7 @@ def test_describe_carrier_gateways_arg_pass(gen_describe_carrier_gateways_pagina
 def test_describe_carrier_gateways_arg_fail(
     gen_describe_local_gateway_route_table_virtual_interface_group_associations_paginator,
 ):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: DescribeCarrierGatewaysPaginator):
@@ -4618,7 +4618,7 @@ def test_get_transit_gateway_prefix_list_references_arg_pass(
 def test_get_transit_gateway_prefix_list_references_arg_fail(
     gen_describe_network_acls_paginator,
 ):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: GetTransitGatewayPrefixListReferencesPaginator):
@@ -4669,7 +4669,7 @@ def test_describe_network_insights_analyses_arg_pass(
 def test_describe_network_insights_analyses_arg_fail(
     gen_describe_launch_templates_paginator,
 ):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: DescribeNetworkInsightsAnalysesPaginator):
@@ -4720,7 +4720,7 @@ def test_describe_network_insights_paths_arg_pass(
 def test_describe_network_insights_paths_arg_fail(
     gen_describe_local_gateway_route_table_vpc_associations_paginator,
 ):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: DescribeNetworkInsightsPathsPaginator):
@@ -4771,7 +4771,7 @@ def test_describe_transit_gateway_connect_peers_arg_pass(
 def test_describe_transit_gateway_connect_peers_arg_fail(
     gen_describe_spot_fleet_requests_paginator,
 ):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: DescribeTransitGatewayConnectPeersPaginator):
@@ -4822,7 +4822,7 @@ def test_describe_transit_gateway_connects_arg_pass(
 def test_describe_transit_gateway_connects_arg_fail(
     gen_describe_capacity_reservations_paginator,
 ):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: DescribeTransitGatewayConnectsPaginator):
@@ -4871,7 +4871,7 @@ def test_describe_addresses_attribute_arg_pass(
 
 
 def test_describe_addresses_attribute_arg_fail(gen_describe_dhcp_options_paginator):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: DescribeAddressesAttributePaginator):
@@ -4920,7 +4920,7 @@ def test_describe_replace_root_volume_tasks_arg_pass(
 def test_describe_replace_root_volume_tasks_arg_fail(
     gen_describe_client_vpn_routes_paginator,
 ):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: DescribeReplaceRootVolumeTasksPaginator):
@@ -4969,7 +4969,7 @@ def test_describe_store_image_tasks_arg_pass(gen_describe_store_image_tasks_pagi
 def test_describe_store_image_tasks_arg_fail(
     gen_describe_addresses_attribute_paginator,
 ):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: DescribeStoreImageTasksPaginator):
@@ -5020,7 +5020,7 @@ def test_describe_security_group_rules_arg_pass(
 def test_describe_security_group_rules_arg_fail(
     gen_describe_instance_credit_specifications_paginator,
 ):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: DescribeSecurityGroupRulesPaginator):
@@ -5071,7 +5071,7 @@ def test_describe_instance_event_windows_arg_pass(
 def test_describe_instance_event_windows_arg_fail(
     gen_describe_instance_status_paginator,
 ):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: DescribeInstanceEventWindowsPaginator):
@@ -5122,7 +5122,7 @@ def test_describe_trunk_interface_associations_arg_pass(
 def test_describe_trunk_interface_associations_arg_fail(
     gen_search_transit_gateway_multicast_groups_paginator,
 ):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: DescribeTrunkInterfaceAssociationsPaginator):
@@ -5171,7 +5171,7 @@ def test_get_vpn_connection_device_types_arg_pass(
 
 
 def test_get_vpn_connection_device_types_arg_fail(gen_describe_subnets_paginator):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: GetVpnConnectionDeviceTypesPaginator):
@@ -5220,7 +5220,7 @@ def test_describe_capacity_reservation_fleets_arg_pass(
 def test_describe_capacity_reservation_fleets_arg_fail(
     gen_describe_scheduled_instance_availability_paginator,
 ):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: DescribeCapacityReservationFleetsPaginator):
@@ -5271,7 +5271,7 @@ def test_get_instance_types_from_instance_requirements_arg_pass(
 def test_get_instance_types_from_instance_requirements_arg_fail(
     gen_describe_moving_addresses_paginator,
 ):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: GetInstanceTypesFromInstanceRequirementsPaginator):
@@ -5318,7 +5318,7 @@ def test_get_spot_placement_scores_arg_pass(gen_get_spot_placement_scores_pagina
 
 
 def test_get_spot_placement_scores_arg_fail(gen_describe_prefix_lists_paginator):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: GetSpotPlacementScoresPaginator):

--- a/tests/ec2/test_ec2_paginators.py
+++ b/tests/ec2/test_ec2_paginators.py
@@ -111,7 +111,7 @@ from bearboto3.ec2 import (
 from beartype import beartype
 from beartype.roar import (
     BeartypeCallHintPepParamException,
-    BeartypeCallHintPepReturnException,
+    BeartypeCallHintReturnViolation,
     BeartypeDecorHintPep484585Exception,
 )
 
@@ -153,7 +153,7 @@ def test_describe_route_tables_return_fail(
     gen_describe_transit_gateway_attachments_paginator,
 ):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -204,7 +204,7 @@ def test_describe_iam_instance_profile_associations_return_fail(
     gen_describe_vpcs_paginator,
 ):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -249,7 +249,7 @@ def test_describe_instance_status_return_fail(
     gen_search_local_gateway_routes_paginator,
 ):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -294,7 +294,7 @@ def test_describe_instances_return_fail(
     gen_describe_replace_root_volume_tasks_paginator,
 ):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -345,7 +345,7 @@ def test_describe_reserved_instances_offerings_return_fail(
     gen_describe_trunk_interface_associations_paginator,
 ):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -396,7 +396,7 @@ def test_describe_reserved_instances_modifications_return_fail(
     gen_describe_dhcp_options_paginator,
 ):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -441,7 +441,7 @@ def test_describe_security_groups_return_fail(
     gen_describe_spot_fleet_instances_paginator,
 ):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -484,7 +484,7 @@ def test_describe_snapshots_return_pass(gen_describe_snapshots_paginator):
 
 def test_describe_snapshots_return_fail(gen_describe_client_vpn_endpoints_paginator):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -535,7 +535,7 @@ def test_describe_spot_fleet_instances_return_fail(
     gen_describe_security_group_rules_paginator,
 ):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -586,7 +586,7 @@ def test_describe_spot_fleet_requests_return_fail(
     gen_describe_local_gateway_route_table_vpc_associations_paginator,
 ):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -637,7 +637,7 @@ def test_describe_spot_price_history_return_fail(
     gen_describe_replace_root_volume_tasks_paginator,
 ):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -680,7 +680,7 @@ def test_describe_tags_return_pass(gen_describe_tags_paginator):
 
 def test_describe_tags_return_fail(gen_describe_flow_logs_paginator):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -725,7 +725,7 @@ def test_describe_volume_status_return_fail(
     gen_describe_network_insights_paths_paginator,
 ):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -768,7 +768,7 @@ def test_describe_volumes_return_pass(gen_describe_volumes_paginator):
 
 def test_describe_volumes_return_fail(gen_describe_instance_event_windows_paginator):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -815,7 +815,7 @@ def test_describe_nat_gateways_return_fail(
     gen_describe_scheduled_instance_availability_paginator,
 ):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -866,7 +866,7 @@ def test_describe_network_interfaces_return_fail(
     gen_describe_client_vpn_connections_paginator,
 ):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -909,7 +909,7 @@ def test_describe_vpc_endpoints_return_pass(gen_describe_vpc_endpoints_paginator
 
 def test_describe_vpc_endpoints_return_fail(gen_describe_byoip_cidrs_paginator):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -960,7 +960,7 @@ def test_describe_vpc_endpoint_services_return_fail(
     gen_describe_public_ipv4_pools_paginator,
 ):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -1011,7 +1011,7 @@ def test_describe_vpc_endpoint_connections_return_fail(
     gen_describe_spot_instance_requests_paginator,
 ):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -1054,7 +1054,7 @@ def test_describe_byoip_cidrs_return_pass(gen_describe_byoip_cidrs_paginator):
 
 def test_describe_byoip_cidrs_return_fail(gen_get_associated_ipv6_pool_cidrs_paginator):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -1105,7 +1105,7 @@ def test_describe_capacity_reservations_return_fail(
     gen_describe_transit_gateway_connects_paginator,
 ):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -1156,7 +1156,7 @@ def test_describe_classic_link_instances_return_fail(
     gen_describe_vpc_endpoint_service_permissions_paginator,
 ):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -1207,7 +1207,7 @@ def test_describe_client_vpn_authorization_rules_return_fail(
     gen_describe_fpga_images_paginator,
 ):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -1256,7 +1256,7 @@ def test_describe_client_vpn_connections_return_fail(
     gen_describe_route_tables_paginator,
 ):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -1303,7 +1303,7 @@ def test_describe_client_vpn_endpoints_return_pass(
 
 def test_describe_client_vpn_endpoints_return_fail(gen_describe_byoip_cidrs_paginator):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -1348,7 +1348,7 @@ def test_describe_client_vpn_routes_return_pass(
 
 def test_describe_client_vpn_routes_return_fail(gen_describe_snapshots_paginator):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -1397,7 +1397,7 @@ def test_describe_client_vpn_target_networks_return_fail(
     gen_describe_subnets_paginator,
 ):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -1448,7 +1448,7 @@ def test_describe_egress_only_internet_gateways_return_fail(
     gen_describe_traffic_mirror_targets_paginator,
 ):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -1491,7 +1491,7 @@ def test_describe_fleets_return_pass(gen_describe_fleets_paginator):
 
 def test_describe_fleets_return_fail(gen_describe_security_groups_paginator):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -1534,7 +1534,7 @@ def test_describe_flow_logs_return_pass(gen_describe_flow_logs_paginator):
 
 def test_describe_flow_logs_return_fail(gen_describe_coip_pools_paginator):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -1577,7 +1577,7 @@ def test_describe_fpga_images_return_pass(gen_describe_fpga_images_paginator):
 
 def test_describe_fpga_images_return_fail(gen_describe_moving_addresses_paginator):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -1628,7 +1628,7 @@ def test_describe_host_reservation_offerings_return_fail(
     gen_describe_client_vpn_target_networks_paginator,
 ):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -1673,7 +1673,7 @@ def test_describe_host_reservations_return_pass(
 
 def test_describe_host_reservations_return_fail(gen_describe_volume_status_paginator):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -1716,7 +1716,7 @@ def test_describe_hosts_return_pass(gen_describe_hosts_paginator):
 
 def test_describe_hosts_return_fail(gen_describe_store_image_tasks_paginator):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -1763,7 +1763,7 @@ def test_describe_import_image_tasks_return_pass(
 
 def test_describe_import_image_tasks_return_fail(gen_describe_tags_paginator):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -1814,7 +1814,7 @@ def test_describe_import_snapshot_tasks_return_fail(
     gen_describe_addresses_attribute_paginator,
 ):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -1865,7 +1865,7 @@ def test_describe_instance_credit_specifications_return_fail(
     gen_describe_network_interfaces_paginator,
 ):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -1916,7 +1916,7 @@ def test_describe_launch_template_versions_return_fail(
     gen_describe_spot_instance_requests_paginator,
 ):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -1959,7 +1959,7 @@ def test_describe_launch_templates_return_pass(gen_describe_launch_templates_pag
 
 def test_describe_launch_templates_return_fail(gen_describe_coip_pools_paginator):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -2002,7 +2002,7 @@ def test_describe_moving_addresses_return_pass(gen_describe_moving_addresses_pag
 
 def test_describe_moving_addresses_return_fail(gen_describe_fpga_images_paginator):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -2053,7 +2053,7 @@ def test_describe_network_interface_permissions_return_fail(
     gen_describe_network_insights_paths_paginator,
 ):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -2098,7 +2098,7 @@ def test_describe_prefix_lists_return_fail(
     gen_describe_volumes_modifications_paginator,
 ):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -2149,7 +2149,7 @@ def test_describe_principal_id_format_return_fail(
     gen_get_associated_ipv6_pool_cidrs_paginator,
 ):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -2198,7 +2198,7 @@ def test_describe_public_ipv4_pools_return_fail(
     gen_describe_local_gateway_virtual_interfaces_paginator,
 ):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -2249,7 +2249,7 @@ def test_describe_scheduled_instance_availability_return_fail(
     gen_get_vpn_connection_device_types_paginator,
 ):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -2298,7 +2298,7 @@ def test_describe_scheduled_instances_return_fail(
     gen_describe_instance_status_paginator,
 ):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -2349,7 +2349,7 @@ def test_describe_stale_security_groups_return_fail(
     gen_get_associated_ipv6_pool_cidrs_paginator,
 ):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -2400,7 +2400,7 @@ def test_describe_transit_gateway_attachments_return_fail(
     gen_describe_local_gateway_route_tables_paginator,
 ):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -2451,7 +2451,7 @@ def test_describe_transit_gateway_route_tables_return_fail(
     gen_describe_launch_templates_paginator,
 ):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -2502,7 +2502,7 @@ def test_describe_transit_gateway_vpc_attachments_return_fail(
     gen_get_instance_types_from_instance_requirements_paginator,
 ):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -2545,7 +2545,7 @@ def test_describe_transit_gateways_return_pass(gen_describe_transit_gateways_pag
 
 def test_describe_transit_gateways_return_fail(gen_describe_route_tables_paginator):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -2594,7 +2594,7 @@ def test_describe_volumes_modifications_return_fail(
     gen_describe_instance_types_paginator,
 ):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -2645,7 +2645,7 @@ def test_describe_vpc_classic_link_dns_support_return_fail(
     gen_get_transit_gateway_multicast_domain_associations_paginator,
 ):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -2696,7 +2696,7 @@ def test_describe_vpc_endpoint_connection_notifications_return_fail(
     gen_describe_launch_templates_paginator,
 ):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -2747,7 +2747,7 @@ def test_describe_vpc_endpoint_service_configurations_return_fail(
     gen_describe_vpcs_paginator,
 ):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -2798,7 +2798,7 @@ def test_describe_vpc_endpoint_service_permissions_return_fail(
     gen_describe_vpc_peering_connections_paginator,
 ):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -2849,7 +2849,7 @@ def test_describe_vpc_peering_connections_return_fail(
     gen_describe_network_insights_paths_paginator,
 ):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -2900,7 +2900,7 @@ def test_get_transit_gateway_attachment_propagations_return_fail(
     gen_get_managed_prefix_list_entries_paginator,
 ):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -2951,7 +2951,7 @@ def test_get_transit_gateway_route_table_associations_return_fail(
     gen_describe_classic_link_instances_paginator,
 ):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -3002,7 +3002,7 @@ def test_get_transit_gateway_route_table_propagations_return_fail(
     gen_describe_ipv6_pools_paginator,
 ):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -3051,7 +3051,7 @@ def test_describe_internet_gateways_return_fail(
     gen_describe_network_insights_analyses_paginator,
 ):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -3096,7 +3096,7 @@ def test_describe_network_acls_return_fail(
     gen_describe_instance_type_offerings_paginator,
 ):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -3139,7 +3139,7 @@ def test_describe_vpcs_return_pass(gen_describe_vpcs_paginator):
 
 def test_describe_vpcs_return_fail(gen_describe_fleets_paginator):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -3190,7 +3190,7 @@ def test_describe_spot_instance_requests_return_fail(
     gen_describe_vpc_endpoint_service_permissions_paginator,
 ):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -3237,7 +3237,7 @@ def test_describe_dhcp_options_return_fail(
     gen_get_transit_gateway_prefix_list_references_paginator,
 ):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -3284,7 +3284,7 @@ def test_describe_subnets_return_fail(
     gen_describe_egress_only_internet_gateways_paginator,
 ):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -3335,7 +3335,7 @@ def test_describe_traffic_mirror_filters_return_fail(
     gen_describe_transit_gateway_vpc_attachments_paginator,
 ):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -3386,7 +3386,7 @@ def test_describe_traffic_mirror_sessions_return_fail(
     gen_describe_client_vpn_connections_paginator,
 ):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -3437,7 +3437,7 @@ def test_describe_traffic_mirror_targets_return_fail(
     gen_describe_vpc_endpoint_services_paginator,
 ):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -3488,7 +3488,7 @@ def test_describe_export_image_tasks_return_fail(
     gen_get_managed_prefix_list_associations_paginator,
 ):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -3539,7 +3539,7 @@ def test_describe_fast_snapshot_restores_return_fail(
     gen_describe_transit_gateway_multicast_domains_paginator,
 ):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -3584,7 +3584,7 @@ def test_describe_ipv6_pools_return_fail(
     gen_describe_launch_template_versions_paginator,
 ):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -3635,7 +3635,7 @@ def test_get_associated_ipv6_pool_cidrs_return_fail(
     gen_describe_spot_fleet_instances_paginator,
 ):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -3678,7 +3678,7 @@ def test_describe_coip_pools_return_pass(gen_describe_coip_pools_paginator):
 
 def test_describe_coip_pools_return_fail(gen_describe_instance_event_windows_paginator):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -3729,7 +3729,7 @@ def test_describe_instance_type_offerings_return_fail(
     gen_describe_traffic_mirror_targets_paginator,
 ):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -3772,7 +3772,7 @@ def test_describe_instance_types_return_pass(gen_describe_instance_types_paginat
 
 def test_describe_instance_types_return_fail(gen_describe_flow_logs_paginator):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -3829,7 +3829,7 @@ def test_describe_local_gateway_route_table_virtual_interface_group_associations
     gen_describe_security_groups_paginator,
 ):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -3880,7 +3880,7 @@ def test_describe_local_gateway_route_table_vpc_associations_return_fail(
     gen_get_managed_prefix_list_entries_paginator,
 ):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -3931,7 +3931,7 @@ def test_describe_local_gateway_route_tables_return_fail(
     gen_describe_managed_prefix_lists_paginator,
 ):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -3982,7 +3982,7 @@ def test_describe_local_gateway_virtual_interface_groups_return_fail(
     gen_describe_subnets_paginator,
 ):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -4033,7 +4033,7 @@ def test_describe_local_gateway_virtual_interfaces_return_fail(
     gen_describe_import_snapshot_tasks_paginator,
 ):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -4080,7 +4080,7 @@ def test_describe_local_gateways_return_fail(
     gen_describe_classic_link_instances_paginator,
 ):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -4131,7 +4131,7 @@ def test_describe_transit_gateway_multicast_domains_return_fail(
     gen_describe_vpc_endpoint_services_paginator,
 ):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -4182,7 +4182,7 @@ def test_describe_transit_gateway_peering_attachments_return_fail(
     gen_describe_export_image_tasks_paginator,
 ):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -4233,7 +4233,7 @@ def test_get_transit_gateway_multicast_domain_associations_return_fail(
     gen_describe_capacity_reservation_fleets_paginator,
 ):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -4286,7 +4286,7 @@ def test_search_local_gateway_routes_return_fail(
     gen_describe_local_gateway_route_table_virtual_interface_group_associations_paginator,
 ):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -4337,7 +4337,7 @@ def test_search_transit_gateway_multicast_groups_return_fail(
     gen_describe_subnets_paginator,
 ):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -4388,7 +4388,7 @@ def test_describe_managed_prefix_lists_return_fail(
     gen_describe_transit_gateway_multicast_domains_paginator,
 ):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -4439,7 +4439,7 @@ def test_get_managed_prefix_list_associations_return_fail(
     gen_get_spot_placement_scores_paginator,
 ):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -4490,7 +4490,7 @@ def test_get_managed_prefix_list_entries_return_fail(
     gen_describe_host_reservation_offerings_paginator,
 ):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -4541,7 +4541,7 @@ def test_get_groups_for_capacity_reservation_return_fail(
     gen_get_transit_gateway_multicast_domain_associations_paginator,
 ):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -4590,7 +4590,7 @@ def test_describe_carrier_gateways_return_fail(
     gen_describe_local_gateway_route_table_virtual_interface_group_associations_paginator,
 ):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -4641,7 +4641,7 @@ def test_get_transit_gateway_prefix_list_references_return_fail(
     gen_describe_network_acls_paginator,
 ):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -4692,7 +4692,7 @@ def test_describe_network_insights_analyses_return_fail(
     gen_describe_launch_templates_paginator,
 ):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -4743,7 +4743,7 @@ def test_describe_network_insights_paths_return_fail(
     gen_describe_local_gateway_route_table_vpc_associations_paginator,
 ):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -4794,7 +4794,7 @@ def test_describe_transit_gateway_connect_peers_return_fail(
     gen_describe_spot_fleet_requests_paginator,
 ):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -4845,7 +4845,7 @@ def test_describe_transit_gateway_connects_return_fail(
     gen_describe_capacity_reservations_paginator,
 ):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -4892,7 +4892,7 @@ def test_describe_addresses_attribute_return_pass(
 
 def test_describe_addresses_attribute_return_fail(gen_describe_dhcp_options_paginator):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -4943,7 +4943,7 @@ def test_describe_replace_root_volume_tasks_return_fail(
     gen_describe_client_vpn_routes_paginator,
 ):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -4992,7 +4992,7 @@ def test_describe_store_image_tasks_return_fail(
     gen_describe_addresses_attribute_paginator,
 ):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -5043,7 +5043,7 @@ def test_describe_security_group_rules_return_fail(
     gen_describe_instance_credit_specifications_paginator,
 ):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -5094,7 +5094,7 @@ def test_describe_instance_event_windows_return_fail(
     gen_describe_instance_status_paginator,
 ):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -5145,7 +5145,7 @@ def test_describe_trunk_interface_associations_return_fail(
     gen_search_transit_gateway_multicast_groups_paginator,
 ):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -5192,7 +5192,7 @@ def test_get_vpn_connection_device_types_return_pass(
 
 def test_get_vpn_connection_device_types_return_fail(gen_describe_subnets_paginator):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -5243,7 +5243,7 @@ def test_describe_capacity_reservation_fleets_return_fail(
     gen_describe_scheduled_instance_availability_paginator,
 ):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -5294,7 +5294,7 @@ def test_get_instance_types_from_instance_requirements_return_fail(
     gen_describe_moving_addresses_paginator,
 ):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -5337,7 +5337,7 @@ def test_get_spot_placement_scores_return_pass(gen_get_spot_placement_scores_pag
 
 def test_get_spot_placement_scores_return_fail(gen_describe_prefix_lists_paginator):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype

--- a/tests/ec2/test_ec2_resources.py
+++ b/tests/ec2/test_ec2_resources.py
@@ -26,7 +26,7 @@ from bearboto3.ec2 import (
 from beartype import beartype
 from beartype.roar import (
     BeartypeCallHintPepParamException,
-    BeartypeCallHintPepReturnException,
+    BeartypeCallHintReturnViolation,
     BeartypeDecorHintPep484585Exception,
 )
 
@@ -63,7 +63,7 @@ def test_classic_address_return_pass(gen_classic_address):
 
 def test_classic_address_return_fail(gen_key_pair):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -106,7 +106,7 @@ def test_dhcp_options_return_pass(gen_dhcp_options):
 
 def test_dhcp_options_return_fail(gen_route_table):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -149,7 +149,7 @@ def test_image_return_pass(gen_image):
 
 def test_image_return_fail(gen_classic_address):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -192,7 +192,7 @@ def test_instance_return_pass(gen_instance):
 
 def test_instance_return_fail(gen_network_acl):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -235,7 +235,7 @@ def test_internet_gateway_return_pass(gen_internet_gateway):
 
 def test_internet_gateway_return_fail(gen_tag):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -278,7 +278,7 @@ def test_key_pair_return_pass(gen_key_pair):
 
 def test_key_pair_return_fail(gen_volume):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -321,7 +321,7 @@ def test_key_pair_info_return_pass(gen_key_pair):
 
 def test_key_pair_info_return_fail(gen_route_table_association):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -364,7 +364,7 @@ def test_network_acl_return_pass(gen_network_acl):
 
 def test_network_acl_return_fail(gen_route_table):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -407,7 +407,7 @@ def test_network_interface_return_pass(gen_network_interface):
 
 def test_network_interface_return_fail(gen_key_pair):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -450,7 +450,7 @@ def test_network_interface_association_return_pass(gen_network_interface_associa
 
 def test_network_interface_association_return_fail(gen_network_interface):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -493,7 +493,7 @@ def test_placement_group_return_pass(gen_placement_group):
 
 def test_placement_group_return_fail(gen_vpc_address):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -536,7 +536,7 @@ def test_route_return_pass(gen_route):
 
 def test_route_return_fail(gen_placement_group):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -579,7 +579,7 @@ def test_route_table_return_pass(gen_route_table):
 
 def test_route_table_return_fail(gen_key_pair):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -622,7 +622,7 @@ def test_route_table_association_return_pass(gen_route_table_association):
 
 def test_route_table_association_return_fail(gen_image):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -665,7 +665,7 @@ def test_security_group_return_pass(gen_security_group):
 
 def test_security_group_return_fail(gen_route):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -708,7 +708,7 @@ def test_snapshot_return_pass(gen_snapshot):
 
 def test_snapshot_return_fail(gen_classic_address):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -751,7 +751,7 @@ def test_subnet_return_pass(gen_subnet):
 
 def test_subnet_return_fail(gen_vpc):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -794,7 +794,7 @@ def test_tag_return_pass(gen_tag):
 
 def test_tag_return_fail(gen_classic_address):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -837,7 +837,7 @@ def test_volume_return_pass(gen_volume):
 
 def test_volume_return_fail(gen_classic_address):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -880,7 +880,7 @@ def test_vpc_return_pass(gen_vpc):
 
 def test_vpc_return_fail(gen_tag):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -923,7 +923,7 @@ def test_vpc_peering_connection_return_pass(gen_vpc_peering_connection):
 
 def test_vpc_peering_connection_return_fail(gen_network_interface_association):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -966,7 +966,7 @@ def test_vpc_address_return_pass(gen_vpc_address):
 
 def test_vpc_address_return_fail(gen_network_interface_association):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype

--- a/tests/ec2/test_ec2_resources.py
+++ b/tests/ec2/test_ec2_resources.py
@@ -25,7 +25,7 @@ from bearboto3.ec2 import (
 )
 from beartype import beartype
 from beartype.roar import (
-    BeartypeCallHintPepParamException,
+    BeartypeCallHintParamViolation,
     BeartypeCallHintReturnViolation,
     BeartypeDecorHintPep484585Exception,
 )
@@ -44,7 +44,7 @@ def test_classic_address_arg_pass(gen_classic_address):
 
 
 def test_classic_address_arg_fail(gen_key_pair):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: ClassicAddress):
@@ -87,7 +87,7 @@ def test_dhcp_options_arg_pass(gen_dhcp_options):
 
 
 def test_dhcp_options_arg_fail(gen_route_table):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: DhcpOptions):
@@ -130,7 +130,7 @@ def test_image_arg_pass(gen_image):
 
 
 def test_image_arg_fail(gen_classic_address):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: Image):
@@ -173,7 +173,7 @@ def test_instance_arg_pass(gen_instance):
 
 
 def test_instance_arg_fail(gen_network_acl):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: Instance):
@@ -216,7 +216,7 @@ def test_internet_gateway_arg_pass(gen_internet_gateway):
 
 
 def test_internet_gateway_arg_fail(gen_tag):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: InternetGateway):
@@ -259,7 +259,7 @@ def test_key_pair_arg_pass(gen_key_pair):
 
 
 def test_key_pair_arg_fail(gen_volume):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: KeyPair):
@@ -302,7 +302,7 @@ def test_key_pair_info_arg_pass(gen_key_pair):
 
 
 def test_key_pair_info_arg_fail(gen_route_table_association):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: KeyPairInfo):
@@ -345,7 +345,7 @@ def test_network_acl_arg_pass(gen_network_acl):
 
 
 def test_network_acl_arg_fail(gen_route_table):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: NetworkAcl):
@@ -388,7 +388,7 @@ def test_network_interface_arg_pass(gen_network_interface):
 
 
 def test_network_interface_arg_fail(gen_key_pair):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: NetworkInterface):
@@ -431,7 +431,7 @@ def test_network_interface_association_arg_pass(gen_network_interface_associatio
 
 
 def test_network_interface_association_arg_fail(gen_network_interface):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: NetworkInterfaceAssociation):
@@ -474,7 +474,7 @@ def test_placement_group_arg_pass(gen_placement_group):
 
 
 def test_placement_group_arg_fail(gen_vpc_address):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: PlacementGroup):
@@ -517,7 +517,7 @@ def test_route_arg_pass(gen_route):
 
 
 def test_route_arg_fail(gen_placement_group):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: Route):
@@ -560,7 +560,7 @@ def test_route_table_arg_pass(gen_route_table):
 
 
 def test_route_table_arg_fail(gen_key_pair):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: RouteTable):
@@ -603,7 +603,7 @@ def test_route_table_association_arg_pass(gen_route_table_association):
 
 
 def test_route_table_association_arg_fail(gen_image):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: RouteTableAssociation):
@@ -646,7 +646,7 @@ def test_security_group_arg_pass(gen_security_group):
 
 
 def test_security_group_arg_fail(gen_route):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: SecurityGroup):
@@ -689,7 +689,7 @@ def test_snapshot_arg_pass(gen_snapshot):
 
 
 def test_snapshot_arg_fail(gen_classic_address):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: Snapshot):
@@ -732,7 +732,7 @@ def test_subnet_arg_pass(gen_subnet):
 
 
 def test_subnet_arg_fail(gen_vpc):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: Subnet):
@@ -775,7 +775,7 @@ def test_tag_arg_pass(gen_tag):
 
 
 def test_tag_arg_fail(gen_classic_address):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: Tag):
@@ -818,7 +818,7 @@ def test_volume_arg_pass(gen_volume):
 
 
 def test_volume_arg_fail(gen_classic_address):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: Volume):
@@ -861,7 +861,7 @@ def test_vpc_arg_pass(gen_vpc):
 
 
 def test_vpc_arg_fail(gen_tag):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: Vpc):
@@ -904,7 +904,7 @@ def test_vpc_peering_connection_arg_pass(gen_vpc_peering_connection):
 
 
 def test_vpc_peering_connection_arg_fail(gen_network_interface_association):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: VpcPeeringConnection):
@@ -947,7 +947,7 @@ def test_vpc_address_arg_pass(gen_vpc_address):
 
 
 def test_vpc_address_arg_fail(gen_network_interface_association):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: VpcAddress):

--- a/tests/ec2/test_ec2_waiters.py
+++ b/tests/ec2/test_ec2_waiters.py
@@ -36,7 +36,7 @@ from bearboto3.ec2 import (
 from beartype import beartype
 from beartype.roar import (
     BeartypeCallHintPepParamException,
-    BeartypeCallHintPepReturnException,
+    BeartypeCallHintReturnViolation,
     BeartypeDecorHintPep484585Exception,
 )
 
@@ -74,7 +74,7 @@ def test_instance_exists_return_pass(gen_instance_exists_waiter):
 
 def test_instance_exists_return_fail(gen_conversion_task_completed_waiter):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -117,7 +117,7 @@ def test_bundle_task_complete_return_pass(gen_bundle_task_complete_waiter):
 
 def test_bundle_task_complete_return_fail(gen_spot_instance_request_fulfilled_waiter):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -160,7 +160,7 @@ def test_conversion_task_cancelled_return_pass(gen_conversion_task_cancelled_wai
 
 def test_conversion_task_cancelled_return_fail(gen_nat_gateway_available_waiter):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -203,7 +203,7 @@ def test_conversion_task_completed_return_pass(gen_conversion_task_completed_wai
 
 def test_conversion_task_completed_return_fail(gen_image_exists_waiter):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -246,7 +246,7 @@ def test_conversion_task_deleted_return_pass(gen_conversion_task_deleted_waiter)
 
 def test_conversion_task_deleted_return_fail(gen_bundle_task_complete_waiter):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -289,7 +289,7 @@ def test_customer_gateway_available_return_pass(gen_customer_gateway_available_w
 
 def test_customer_gateway_available_return_fail(gen_bundle_task_complete_waiter):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -332,7 +332,7 @@ def test_export_task_cancelled_return_pass(gen_export_task_cancelled_waiter):
 
 def test_export_task_cancelled_return_fail(gen_subnet_available_waiter):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -375,7 +375,7 @@ def test_export_task_completed_return_pass(gen_export_task_completed_waiter):
 
 def test_export_task_completed_return_fail(gen_vpc_peering_connection_deleted_waiter):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -418,7 +418,7 @@ def test_image_exists_return_pass(gen_image_exists_waiter):
 
 def test_image_exists_return_fail(gen_password_data_available_waiter):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -461,7 +461,7 @@ def test_image_available_return_pass(gen_image_available_waiter):
 
 def test_image_available_return_fail(gen_export_task_cancelled_waiter):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -504,7 +504,7 @@ def test_instance_running_return_pass(gen_instance_running_waiter):
 
 def test_instance_running_return_fail(gen_volume_available_waiter):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -547,7 +547,7 @@ def test_instance_status_ok_return_pass(gen_instance_status_ok_waiter):
 
 def test_instance_status_ok_return_fail(gen_instance_stopped_waiter):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -590,7 +590,7 @@ def test_instance_stopped_return_pass(gen_instance_stopped_waiter):
 
 def test_instance_stopped_return_fail(gen_bundle_task_complete_waiter):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -633,7 +633,7 @@ def test_instance_terminated_return_pass(gen_instance_terminated_waiter):
 
 def test_instance_terminated_return_fail(gen_network_interface_available_waiter):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -676,7 +676,7 @@ def test_key_pair_exists_return_pass(gen_key_pair_exists_waiter):
 
 def test_key_pair_exists_return_fail(gen_snapshot_completed_waiter):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -719,7 +719,7 @@ def test_nat_gateway_available_return_pass(gen_nat_gateway_available_waiter):
 
 def test_nat_gateway_available_return_fail(gen_bundle_task_complete_waiter):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -764,7 +764,7 @@ def test_network_interface_available_return_pass(
 
 def test_network_interface_available_return_fail(gen_volume_deleted_waiter):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -807,7 +807,7 @@ def test_password_data_available_return_pass(gen_password_data_available_waiter)
 
 def test_password_data_available_return_fail(gen_key_pair_exists_waiter):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -850,7 +850,7 @@ def test_snapshot_completed_return_pass(gen_snapshot_completed_waiter):
 
 def test_snapshot_completed_return_fail(gen_instance_running_waiter):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -893,7 +893,7 @@ def test_security_group_exists_return_pass(gen_security_group_exists_waiter):
 
 def test_security_group_exists_return_fail(gen_volume_available_waiter):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -940,7 +940,7 @@ def test_spot_instance_request_fulfilled_return_pass(
 
 def test_spot_instance_request_fulfilled_return_fail(gen_instance_stopped_waiter):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -983,7 +983,7 @@ def test_subnet_available_return_pass(gen_subnet_available_waiter):
 
 def test_subnet_available_return_fail(gen_vpc_peering_connection_deleted_waiter):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -1026,7 +1026,7 @@ def test_system_status_ok_return_pass(gen_system_status_ok_waiter):
 
 def test_system_status_ok_return_fail(gen_export_task_cancelled_waiter):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -1069,7 +1069,7 @@ def test_volume_available_return_pass(gen_volume_available_waiter):
 
 def test_volume_available_return_fail(gen_vpn_connection_deleted_waiter):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -1112,7 +1112,7 @@ def test_volume_deleted_return_pass(gen_volume_deleted_waiter):
 
 def test_volume_deleted_return_fail(gen_vpc_peering_connection_deleted_waiter):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -1155,7 +1155,7 @@ def test_volume_in_use_return_pass(gen_volume_in_use_waiter):
 
 def test_volume_in_use_return_fail(gen_conversion_task_deleted_waiter):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -1198,7 +1198,7 @@ def test_vpc_available_return_pass(gen_vpc_available_waiter):
 
 def test_vpc_available_return_fail(gen_vpc_peering_connection_deleted_waiter):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -1241,7 +1241,7 @@ def test_vpc_exists_return_pass(gen_vpc_exists_waiter):
 
 def test_vpc_exists_return_fail(gen_instance_terminated_waiter):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -1284,7 +1284,7 @@ def test_vpn_connection_available_return_pass(gen_vpn_connection_available_waite
 
 def test_vpn_connection_available_return_fail(gen_customer_gateway_available_waiter):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -1327,7 +1327,7 @@ def test_vpn_connection_deleted_return_pass(gen_vpn_connection_deleted_waiter):
 
 def test_vpn_connection_deleted_return_fail(gen_volume_available_waiter):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -1374,7 +1374,7 @@ def test_vpc_peering_connection_exists_return_pass(
 
 def test_vpc_peering_connection_exists_return_fail(gen_instance_exists_waiter):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -1421,7 +1421,7 @@ def test_vpc_peering_connection_deleted_return_pass(
 
 def test_vpc_peering_connection_deleted_return_fail(gen_volume_deleted_waiter):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype

--- a/tests/ec2/test_ec2_waiters.py
+++ b/tests/ec2/test_ec2_waiters.py
@@ -35,7 +35,7 @@ from bearboto3.ec2 import (
 )
 from beartype import beartype
 from beartype.roar import (
-    BeartypeCallHintPepParamException,
+    BeartypeCallHintParamViolation,
     BeartypeCallHintReturnViolation,
     BeartypeDecorHintPep484585Exception,
 )
@@ -55,7 +55,7 @@ def test_instance_exists_arg_pass(gen_instance_exists_waiter):
 
 
 def test_instance_exists_arg_fail(gen_conversion_task_completed_waiter):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: InstanceExistsWaiter):
@@ -98,7 +98,7 @@ def test_bundle_task_complete_arg_pass(gen_bundle_task_complete_waiter):
 
 
 def test_bundle_task_complete_arg_fail(gen_spot_instance_request_fulfilled_waiter):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: BundleTaskCompleteWaiter):
@@ -141,7 +141,7 @@ def test_conversion_task_cancelled_arg_pass(gen_conversion_task_cancelled_waiter
 
 
 def test_conversion_task_cancelled_arg_fail(gen_nat_gateway_available_waiter):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: ConversionTaskCancelledWaiter):
@@ -184,7 +184,7 @@ def test_conversion_task_completed_arg_pass(gen_conversion_task_completed_waiter
 
 
 def test_conversion_task_completed_arg_fail(gen_image_exists_waiter):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: ConversionTaskCompletedWaiter):
@@ -227,7 +227,7 @@ def test_conversion_task_deleted_arg_pass(gen_conversion_task_deleted_waiter):
 
 
 def test_conversion_task_deleted_arg_fail(gen_bundle_task_complete_waiter):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: ConversionTaskDeletedWaiter):
@@ -270,7 +270,7 @@ def test_customer_gateway_available_arg_pass(gen_customer_gateway_available_wait
 
 
 def test_customer_gateway_available_arg_fail(gen_bundle_task_complete_waiter):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: CustomerGatewayAvailableWaiter):
@@ -313,7 +313,7 @@ def test_export_task_cancelled_arg_pass(gen_export_task_cancelled_waiter):
 
 
 def test_export_task_cancelled_arg_fail(gen_subnet_available_waiter):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: ExportTaskCancelledWaiter):
@@ -356,7 +356,7 @@ def test_export_task_completed_arg_pass(gen_export_task_completed_waiter):
 
 
 def test_export_task_completed_arg_fail(gen_vpc_peering_connection_deleted_waiter):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: ExportTaskCompletedWaiter):
@@ -399,7 +399,7 @@ def test_image_exists_arg_pass(gen_image_exists_waiter):
 
 
 def test_image_exists_arg_fail(gen_password_data_available_waiter):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: ImageExistsWaiter):
@@ -442,7 +442,7 @@ def test_image_available_arg_pass(gen_image_available_waiter):
 
 
 def test_image_available_arg_fail(gen_export_task_cancelled_waiter):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: ImageAvailableWaiter):
@@ -485,7 +485,7 @@ def test_instance_running_arg_pass(gen_instance_running_waiter):
 
 
 def test_instance_running_arg_fail(gen_volume_available_waiter):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: InstanceRunningWaiter):
@@ -528,7 +528,7 @@ def test_instance_status_ok_arg_pass(gen_instance_status_ok_waiter):
 
 
 def test_instance_status_ok_arg_fail(gen_instance_stopped_waiter):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: InstanceStatusOkWaiter):
@@ -571,7 +571,7 @@ def test_instance_stopped_arg_pass(gen_instance_stopped_waiter):
 
 
 def test_instance_stopped_arg_fail(gen_bundle_task_complete_waiter):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: InstanceStoppedWaiter):
@@ -614,7 +614,7 @@ def test_instance_terminated_arg_pass(gen_instance_terminated_waiter):
 
 
 def test_instance_terminated_arg_fail(gen_network_interface_available_waiter):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: InstanceTerminatedWaiter):
@@ -657,7 +657,7 @@ def test_key_pair_exists_arg_pass(gen_key_pair_exists_waiter):
 
 
 def test_key_pair_exists_arg_fail(gen_snapshot_completed_waiter):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: KeyPairExistsWaiter):
@@ -700,7 +700,7 @@ def test_nat_gateway_available_arg_pass(gen_nat_gateway_available_waiter):
 
 
 def test_nat_gateway_available_arg_fail(gen_bundle_task_complete_waiter):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: NatGatewayAvailableWaiter):
@@ -743,7 +743,7 @@ def test_network_interface_available_arg_pass(gen_network_interface_available_wa
 
 
 def test_network_interface_available_arg_fail(gen_volume_deleted_waiter):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: NetworkInterfaceAvailableWaiter):
@@ -788,7 +788,7 @@ def test_password_data_available_arg_pass(gen_password_data_available_waiter):
 
 
 def test_password_data_available_arg_fail(gen_key_pair_exists_waiter):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: PasswordDataAvailableWaiter):
@@ -831,7 +831,7 @@ def test_snapshot_completed_arg_pass(gen_snapshot_completed_waiter):
 
 
 def test_snapshot_completed_arg_fail(gen_instance_running_waiter):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: SnapshotCompletedWaiter):
@@ -874,7 +874,7 @@ def test_security_group_exists_arg_pass(gen_security_group_exists_waiter):
 
 
 def test_security_group_exists_arg_fail(gen_volume_available_waiter):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: SecurityGroupExistsWaiter):
@@ -919,7 +919,7 @@ def test_spot_instance_request_fulfilled_arg_pass(
 
 
 def test_spot_instance_request_fulfilled_arg_fail(gen_instance_stopped_waiter):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: SpotInstanceRequestFulfilledWaiter):
@@ -964,7 +964,7 @@ def test_subnet_available_arg_pass(gen_subnet_available_waiter):
 
 
 def test_subnet_available_arg_fail(gen_vpc_peering_connection_deleted_waiter):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: SubnetAvailableWaiter):
@@ -1007,7 +1007,7 @@ def test_system_status_ok_arg_pass(gen_system_status_ok_waiter):
 
 
 def test_system_status_ok_arg_fail(gen_export_task_cancelled_waiter):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: SystemStatusOkWaiter):
@@ -1050,7 +1050,7 @@ def test_volume_available_arg_pass(gen_volume_available_waiter):
 
 
 def test_volume_available_arg_fail(gen_vpn_connection_deleted_waiter):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: VolumeAvailableWaiter):
@@ -1093,7 +1093,7 @@ def test_volume_deleted_arg_pass(gen_volume_deleted_waiter):
 
 
 def test_volume_deleted_arg_fail(gen_vpc_peering_connection_deleted_waiter):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: VolumeDeletedWaiter):
@@ -1136,7 +1136,7 @@ def test_volume_in_use_arg_pass(gen_volume_in_use_waiter):
 
 
 def test_volume_in_use_arg_fail(gen_conversion_task_deleted_waiter):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: VolumeInUseWaiter):
@@ -1179,7 +1179,7 @@ def test_vpc_available_arg_pass(gen_vpc_available_waiter):
 
 
 def test_vpc_available_arg_fail(gen_vpc_peering_connection_deleted_waiter):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: VpcAvailableWaiter):
@@ -1222,7 +1222,7 @@ def test_vpc_exists_arg_pass(gen_vpc_exists_waiter):
 
 
 def test_vpc_exists_arg_fail(gen_instance_terminated_waiter):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: VpcExistsWaiter):
@@ -1265,7 +1265,7 @@ def test_vpn_connection_available_arg_pass(gen_vpn_connection_available_waiter):
 
 
 def test_vpn_connection_available_arg_fail(gen_customer_gateway_available_waiter):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: VpnConnectionAvailableWaiter):
@@ -1308,7 +1308,7 @@ def test_vpn_connection_deleted_arg_pass(gen_vpn_connection_deleted_waiter):
 
 
 def test_vpn_connection_deleted_arg_fail(gen_volume_available_waiter):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: VpnConnectionDeletedWaiter):
@@ -1353,7 +1353,7 @@ def test_vpc_peering_connection_exists_arg_pass(
 
 
 def test_vpc_peering_connection_exists_arg_fail(gen_instance_exists_waiter):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: VpcPeeringConnectionExistsWaiter):
@@ -1400,7 +1400,7 @@ def test_vpc_peering_connection_deleted_arg_pass(
 
 
 def test_vpc_peering_connection_deleted_arg_fail(gen_volume_deleted_waiter):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: VpcPeeringConnectionDeletedWaiter):

--- a/tests/iam/test_iam_clients.py
+++ b/tests/iam/test_iam_clients.py
@@ -5,7 +5,7 @@ from bearboto3.iam import (
 )
 from beartype import beartype
 from beartype.roar import (
-    BeartypeCallHintPepParamException,
+    BeartypeCallHintParamViolation,
     BeartypeCallHintReturnViolation,
     BeartypeDecorHintPep484585Exception,
 )
@@ -25,7 +25,7 @@ def test_iam_client_arg_pass(gen_iam_client):
 
 
 def test_iam_client_arg_fail(gen_s3_client):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: IAMClient):
@@ -68,7 +68,7 @@ def test_iam_resource_arg_pass(gen_iam_resource):
 
 
 def test_iam_resource_arg_fail(gen_s3_resource):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: IAMServiceResource):

--- a/tests/iam/test_iam_clients.py
+++ b/tests/iam/test_iam_clients.py
@@ -6,7 +6,7 @@ from bearboto3.iam import (
 from beartype import beartype
 from beartype.roar import (
     BeartypeCallHintPepParamException,
-    BeartypeCallHintPepReturnException,
+    BeartypeCallHintReturnViolation,
     BeartypeDecorHintPep484585Exception,
 )
 
@@ -44,7 +44,7 @@ def test_iam_client_return_pass(gen_iam_client):
 
 def test_iam_client_return_fail(gen_s3_client):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -87,7 +87,7 @@ def test_iam_resource_return_pass(gen_iam_resource):
 
 def test_iam_resource_return_fail(gen_s3_resource):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype

--- a/tests/iam/test_iam_collections.py
+++ b/tests/iam/test_iam_collections.py
@@ -30,7 +30,7 @@ from bearboto3.iam import (
 )
 from beartype import beartype
 from beartype.roar import (
-    BeartypeCallHintPepParamException,
+    BeartypeCallHintParamViolation,
     BeartypeCallHintReturnViolation,
     BeartypeDecorHintPep484585Exception,
 )
@@ -50,7 +50,7 @@ def test_groups_arg_pass(gen_service_resource_groups_collection):
 
 
 def test_groups_arg_fail(gen_current_user_access_keys_collection):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: ServiceResourceGroupsCollection):
@@ -93,7 +93,7 @@ def test_instance_profiles_arg_pass(gen_service_resource_instance_profiles_colle
 
 
 def test_instance_profiles_arg_fail(gen_user_groups_collection):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: ServiceResourceInstanceProfilesCollection):
@@ -138,7 +138,7 @@ def test_policies_arg_pass(gen_service_resource_policies_collection):
 
 
 def test_policies_arg_fail(gen_service_resource_roles_collection):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: ServiceResourcePoliciesCollection):
@@ -181,7 +181,7 @@ def test_roles_arg_pass(gen_service_resource_roles_collection):
 
 
 def test_roles_arg_fail(gen_group_attached_policies_collection):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: ServiceResourceRolesCollection):
@@ -224,7 +224,7 @@ def test_saml_providers_arg_pass(gen_service_resource_saml_providers_collection)
 
 
 def test_saml_providers_arg_fail(gen_user_groups_collection):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: ServiceResourceSamlProvidersCollection):
@@ -269,7 +269,7 @@ def test_server_certificates_arg_pass(
 
 
 def test_server_certificates_arg_fail(gen_service_resource_saml_providers_collection):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: ServiceResourceServerCertificatesCollection):
@@ -316,7 +316,7 @@ def test_users_arg_pass(gen_service_resource_users_collection):
 
 
 def test_users_arg_fail(gen_policy_attached_roles_collection):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: ServiceResourceUsersCollection):
@@ -361,7 +361,7 @@ def test_virtual_mfa_devices_arg_pass(
 
 
 def test_virtual_mfa_devices_arg_fail(gen_service_resource_users_collection):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: ServiceResourceVirtualMfaDevicesCollection):
@@ -406,7 +406,7 @@ def test_access_keys_arg_pass(gen_current_user_access_keys_collection):
 
 
 def test_access_keys_arg_fail(gen_user_groups_collection):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: CurrentUserAccessKeysCollection):
@@ -449,7 +449,7 @@ def test_mfa_devices_arg_pass(gen_current_user_mfa_devices_collection):
 
 
 def test_mfa_devices_arg_fail(gen_service_resource_groups_collection):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: CurrentUserMfaDevicesCollection):
@@ -496,7 +496,7 @@ def test_signing_certificates_arg_pass(
 def test_signing_certificates_arg_fail(
     gen_service_resource_server_certificates_collection,
 ):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: CurrentUserSigningCertificatesCollection):
@@ -543,7 +543,7 @@ def test_attached_policies_arg_pass(gen_group_attached_policies_collection):
 
 
 def test_attached_policies_arg_fail(gen_policy_attached_roles_collection):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: GroupAttachedPoliciesCollection):
@@ -586,7 +586,7 @@ def test_policies_arg_pass(gen_group_policies_collection):
 
 
 def test_policies_arg_fail(gen_service_resource_roles_collection):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: GroupPoliciesCollection):
@@ -629,7 +629,7 @@ def test_users_arg_pass(gen_group_users_collection):
 
 
 def test_users_arg_fail(gen_role_instance_profiles_collection):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: GroupUsersCollection):
@@ -672,7 +672,7 @@ def test_attached_groups_arg_pass(gen_policy_attached_groups_collection):
 
 
 def test_attached_groups_arg_fail(gen_service_resource_users_collection):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: PolicyAttachedGroupsCollection):
@@ -715,7 +715,7 @@ def test_attached_roles_arg_pass(gen_policy_attached_roles_collection):
 
 
 def test_attached_roles_arg_fail(gen_user_access_keys_collection):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: PolicyAttachedRolesCollection):
@@ -758,7 +758,7 @@ def test_attached_users_arg_pass(gen_policy_attached_users_collection):
 
 
 def test_attached_users_arg_fail(gen_service_resource_roles_collection):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: PolicyAttachedUsersCollection):
@@ -801,7 +801,7 @@ def test_versions_arg_pass(gen_policy_versions_collection):
 
 
 def test_versions_arg_fail(gen_service_resource_users_collection):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: PolicyVersionsCollection):
@@ -844,7 +844,7 @@ def test_attached_policies_arg_pass(gen_role_attached_policies_collection):
 
 
 def test_attached_policies_arg_fail(gen_service_resource_roles_collection):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: RoleAttachedPoliciesCollection):
@@ -887,7 +887,7 @@ def test_instance_profiles_arg_pass(gen_role_instance_profiles_collection):
 
 
 def test_instance_profiles_arg_fail(gen_user_access_keys_collection):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: RoleInstanceProfilesCollection):
@@ -930,7 +930,7 @@ def test_policies_arg_pass(gen_role_policies_collection):
 
 
 def test_policies_arg_fail(gen_user_groups_collection):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: RolePoliciesCollection):
@@ -973,7 +973,7 @@ def test_access_keys_arg_pass(gen_user_access_keys_collection):
 
 
 def test_access_keys_arg_fail(gen_user_signing_certificates_collection):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: UserAccessKeysCollection):
@@ -1016,7 +1016,7 @@ def test_attached_policies_arg_pass(gen_user_attached_policies_collection):
 
 
 def test_attached_policies_arg_fail(gen_policy_attached_roles_collection):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: UserAttachedPoliciesCollection):
@@ -1059,7 +1059,7 @@ def test_groups_arg_pass(gen_user_groups_collection):
 
 
 def test_groups_arg_fail(gen_role_instance_profiles_collection):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: UserGroupsCollection):
@@ -1102,7 +1102,7 @@ def test_mfa_devices_arg_pass(gen_user_mfa_devices_collection):
 
 
 def test_mfa_devices_arg_fail(gen_service_resource_instance_profiles_collection):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: UserMfaDevicesCollection):
@@ -1145,7 +1145,7 @@ def test_policies_arg_pass(gen_user_policies_collection):
 
 
 def test_policies_arg_fail(gen_policy_attached_groups_collection):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: UserPoliciesCollection):
@@ -1188,7 +1188,7 @@ def test_signing_certificates_arg_pass(gen_user_signing_certificates_collection)
 
 
 def test_signing_certificates_arg_fail(gen_user_access_keys_collection):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: UserSigningCertificatesCollection):

--- a/tests/iam/test_iam_collections.py
+++ b/tests/iam/test_iam_collections.py
@@ -31,7 +31,7 @@ from bearboto3.iam import (
 from beartype import beartype
 from beartype.roar import (
     BeartypeCallHintPepParamException,
-    BeartypeCallHintPepReturnException,
+    BeartypeCallHintReturnViolation,
     BeartypeDecorHintPep484585Exception,
 )
 
@@ -69,7 +69,7 @@ def test_groups_return_pass(gen_service_resource_groups_collection):
 
 def test_groups_return_fail(gen_current_user_access_keys_collection):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -114,7 +114,7 @@ def test_instance_profiles_return_pass(
 
 def test_instance_profiles_return_fail(gen_user_groups_collection):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -157,7 +157,7 @@ def test_policies_return_pass(gen_service_resource_policies_collection):
 
 def test_policies_return_fail(gen_service_resource_roles_collection):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -200,7 +200,7 @@ def test_roles_return_pass(gen_service_resource_roles_collection):
 
 def test_roles_return_fail(gen_group_attached_policies_collection):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -243,7 +243,7 @@ def test_saml_providers_return_pass(gen_service_resource_saml_providers_collecti
 
 def test_saml_providers_return_fail(gen_user_groups_collection):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -292,7 +292,7 @@ def test_server_certificates_return_fail(
     gen_service_resource_saml_providers_collection,
 ):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -335,7 +335,7 @@ def test_users_return_pass(gen_service_resource_users_collection):
 
 def test_users_return_fail(gen_policy_attached_roles_collection):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -382,7 +382,7 @@ def test_virtual_mfa_devices_return_pass(
 
 def test_virtual_mfa_devices_return_fail(gen_service_resource_users_collection):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -425,7 +425,7 @@ def test_access_keys_return_pass(gen_current_user_access_keys_collection):
 
 def test_access_keys_return_fail(gen_user_groups_collection):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -468,7 +468,7 @@ def test_mfa_devices_return_pass(gen_current_user_mfa_devices_collection):
 
 def test_mfa_devices_return_fail(gen_service_resource_groups_collection):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -519,7 +519,7 @@ def test_signing_certificates_return_fail(
     gen_service_resource_server_certificates_collection,
 ):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -562,7 +562,7 @@ def test_attached_policies_return_pass(gen_group_attached_policies_collection):
 
 def test_attached_policies_return_fail(gen_policy_attached_roles_collection):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -605,7 +605,7 @@ def test_policies_return_pass(gen_group_policies_collection):
 
 def test_policies_return_fail(gen_service_resource_roles_collection):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -648,7 +648,7 @@ def test_users_return_pass(gen_group_users_collection):
 
 def test_users_return_fail(gen_role_instance_profiles_collection):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -691,7 +691,7 @@ def test_attached_groups_return_pass(gen_policy_attached_groups_collection):
 
 def test_attached_groups_return_fail(gen_service_resource_users_collection):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -734,7 +734,7 @@ def test_attached_roles_return_pass(gen_policy_attached_roles_collection):
 
 def test_attached_roles_return_fail(gen_user_access_keys_collection):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -777,7 +777,7 @@ def test_attached_users_return_pass(gen_policy_attached_users_collection):
 
 def test_attached_users_return_fail(gen_service_resource_roles_collection):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -820,7 +820,7 @@ def test_versions_return_pass(gen_policy_versions_collection):
 
 def test_versions_return_fail(gen_service_resource_users_collection):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -863,7 +863,7 @@ def test_attached_policies_return_pass(gen_role_attached_policies_collection):
 
 def test_attached_policies_return_fail(gen_service_resource_roles_collection):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -906,7 +906,7 @@ def test_instance_profiles_return_pass(gen_role_instance_profiles_collection):
 
 def test_instance_profiles_return_fail(gen_user_access_keys_collection):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -949,7 +949,7 @@ def test_policies_return_pass(gen_role_policies_collection):
 
 def test_policies_return_fail(gen_user_groups_collection):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -992,7 +992,7 @@ def test_access_keys_return_pass(gen_user_access_keys_collection):
 
 def test_access_keys_return_fail(gen_user_signing_certificates_collection):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -1035,7 +1035,7 @@ def test_attached_policies_return_pass(gen_user_attached_policies_collection):
 
 def test_attached_policies_return_fail(gen_policy_attached_roles_collection):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -1078,7 +1078,7 @@ def test_groups_return_pass(gen_user_groups_collection):
 
 def test_groups_return_fail(gen_role_instance_profiles_collection):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -1121,7 +1121,7 @@ def test_mfa_devices_return_pass(gen_user_mfa_devices_collection):
 
 def test_mfa_devices_return_fail(gen_service_resource_instance_profiles_collection):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -1164,7 +1164,7 @@ def test_policies_return_pass(gen_user_policies_collection):
 
 def test_policies_return_fail(gen_policy_attached_groups_collection):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -1207,7 +1207,7 @@ def test_signing_certificates_return_pass(gen_user_signing_certificates_collecti
 
 def test_signing_certificates_return_fail(gen_user_access_keys_collection):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype

--- a/tests/iam/test_iam_paginators.py
+++ b/tests/iam/test_iam_paginators.py
@@ -30,7 +30,7 @@ from bearboto3.iam import (
 )
 from beartype import beartype
 from beartype.roar import (
-    BeartypeCallHintPepParamException,
+    BeartypeCallHintParamViolation,
     BeartypeCallHintReturnViolation,
     BeartypeDecorHintPep484585Exception,
 )
@@ -52,7 +52,7 @@ def test_get_account_authorization_details_arg_pass(
 
 
 def test_get_account_authorization_details_arg_fail(gen_list_group_policies_paginator):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: GetAccountAuthorizationDetailsPaginator):
@@ -99,7 +99,7 @@ def test_get_group_arg_pass(gen_get_group_paginator):
 
 
 def test_get_group_arg_fail(gen_list_roles_paginator):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: GetGroupPaginator):
@@ -142,7 +142,7 @@ def test_list_access_keys_arg_pass(gen_list_access_keys_paginator):
 
 
 def test_list_access_keys_arg_fail(gen_list_user_policies_paginator):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: ListAccessKeysPaginator):
@@ -185,7 +185,7 @@ def test_list_account_aliases_arg_pass(gen_list_account_aliases_paginator):
 
 
 def test_list_account_aliases_arg_fail(gen_list_ssh_public_keys_paginator):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: ListAccountAliasesPaginator):
@@ -230,7 +230,7 @@ def test_list_attached_group_policies_arg_pass(
 
 
 def test_list_attached_group_policies_arg_fail(gen_list_user_policies_paginator):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: ListAttachedGroupPoliciesPaginator):
@@ -277,7 +277,7 @@ def test_list_attached_role_policies_arg_pass(
 
 
 def test_list_attached_role_policies_arg_fail(gen_list_server_certificates_paginator):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: ListAttachedRolePoliciesPaginator):
@@ -326,7 +326,7 @@ def test_list_attached_user_policies_arg_pass(
 
 
 def test_list_attached_user_policies_arg_fail(gen_list_roles_paginator):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: ListAttachedUserPoliciesPaginator):
@@ -371,7 +371,7 @@ def test_list_entities_for_policy_arg_pass(gen_list_entities_for_policy_paginato
 
 
 def test_list_entities_for_policy_arg_fail(gen_get_group_paginator):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: ListEntitiesForPolicyPaginator):
@@ -414,7 +414,7 @@ def test_list_group_policies_arg_pass(gen_list_group_policies_paginator):
 
 
 def test_list_group_policies_arg_fail(gen_get_group_paginator):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: ListGroupPoliciesPaginator):
@@ -457,7 +457,7 @@ def test_list_groups_arg_pass(gen_list_groups_paginator):
 
 
 def test_list_groups_arg_fail(gen_list_account_aliases_paginator):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: ListGroupsPaginator):
@@ -500,7 +500,7 @@ def test_list_groups_for_user_arg_pass(gen_list_groups_for_user_paginator):
 
 
 def test_list_groups_for_user_arg_fail(gen_list_policies_paginator):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: ListGroupsForUserPaginator):
@@ -543,7 +543,7 @@ def test_list_instance_profiles_arg_pass(gen_list_instance_profiles_paginator):
 
 
 def test_list_instance_profiles_arg_fail(gen_list_groups_for_user_paginator):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: ListInstanceProfilesPaginator):
@@ -588,7 +588,7 @@ def test_list_instance_profiles_for_role_arg_pass(
 
 
 def test_list_instance_profiles_for_role_arg_fail(gen_list_group_policies_paginator):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: ListInstanceProfilesForRolePaginator):
@@ -633,7 +633,7 @@ def test_list_mfa_devices_arg_pass(gen_list_mfa_devices_paginator):
 
 
 def test_list_mfa_devices_arg_fail(gen_list_instance_profiles_for_role_paginator):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: ListMFADevicesPaginator):
@@ -676,7 +676,7 @@ def test_list_policies_arg_pass(gen_list_policies_paginator):
 
 
 def test_list_policies_arg_fail(gen_list_role_policies_paginator):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: ListPoliciesPaginator):
@@ -719,7 +719,7 @@ def test_list_policy_versions_arg_pass(gen_list_policy_versions_paginator):
 
 
 def test_list_policy_versions_arg_fail(gen_list_account_aliases_paginator):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: ListPolicyVersionsPaginator):
@@ -762,7 +762,7 @@ def test_list_role_policies_arg_pass(gen_list_role_policies_paginator):
 
 
 def test_list_role_policies_arg_fail(gen_list_policies_paginator):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: ListRolePoliciesPaginator):
@@ -805,7 +805,7 @@ def test_list_roles_arg_pass(gen_list_roles_paginator):
 
 
 def test_list_roles_arg_fail(gen_list_group_policies_paginator):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: ListRolesPaginator):
@@ -848,7 +848,7 @@ def test_list_server_certificates_arg_pass(gen_list_server_certificates_paginato
 
 
 def test_list_server_certificates_arg_fail(gen_list_user_policies_paginator):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: ListServerCertificatesPaginator):
@@ -891,7 +891,7 @@ def test_list_signing_certificates_arg_pass(gen_list_signing_certificates_pagina
 
 
 def test_list_signing_certificates_arg_fail(gen_list_group_policies_paginator):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: ListSigningCertificatesPaginator):
@@ -934,7 +934,7 @@ def test_list_ssh_public_keys_arg_pass(gen_list_ssh_public_keys_paginator):
 
 
 def test_list_ssh_public_keys_arg_fail(gen_list_users_paginator):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: ListSSHPublicKeysPaginator):
@@ -977,7 +977,7 @@ def test_list_user_policies_arg_pass(gen_list_user_policies_paginator):
 
 
 def test_list_user_policies_arg_fail(gen_list_groups_paginator):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: ListUserPoliciesPaginator):
@@ -1020,7 +1020,7 @@ def test_list_users_arg_pass(gen_list_users_paginator):
 
 
 def test_list_users_arg_fail(gen_get_group_paginator):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: ListUsersPaginator):
@@ -1063,7 +1063,7 @@ def test_list_virtual_mfa_devices_arg_pass(gen_list_virtual_mfa_devices_paginato
 
 
 def test_list_virtual_mfa_devices_arg_fail(gen_list_policy_versions_paginator):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: ListVirtualMFADevicesPaginator):
@@ -1106,7 +1106,7 @@ def test_simulate_custom_policy_arg_pass(gen_simulate_custom_policy_paginator):
 
 
 def test_simulate_custom_policy_arg_fail(gen_list_instance_profiles_paginator):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: SimulateCustomPolicyPaginator):
@@ -1149,7 +1149,7 @@ def test_simulate_principal_policy_arg_pass(gen_simulate_principal_policy_pagina
 
 
 def test_simulate_principal_policy_arg_fail(gen_list_policy_versions_paginator):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: SimulatePrincipalPolicyPaginator):
@@ -1192,7 +1192,7 @@ def test_list_user_tags_arg_pass(gen_list_user_tags_paginator):
 
 
 def test_list_user_tags_arg_fail(gen_get_account_authorization_details_paginator):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: ListUserTagsPaginator):

--- a/tests/iam/test_iam_paginators.py
+++ b/tests/iam/test_iam_paginators.py
@@ -31,7 +31,7 @@ from bearboto3.iam import (
 from beartype import beartype
 from beartype.roar import (
     BeartypeCallHintPepParamException,
-    BeartypeCallHintPepReturnException,
+    BeartypeCallHintReturnViolation,
     BeartypeDecorHintPep484585Exception,
 )
 
@@ -75,7 +75,7 @@ def test_get_account_authorization_details_return_fail(
     gen_list_group_policies_paginator,
 ):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -118,7 +118,7 @@ def test_get_group_return_pass(gen_get_group_paginator):
 
 def test_get_group_return_fail(gen_list_roles_paginator):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -161,7 +161,7 @@ def test_list_access_keys_return_pass(gen_list_access_keys_paginator):
 
 def test_list_access_keys_return_fail(gen_list_user_policies_paginator):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -204,7 +204,7 @@ def test_list_account_aliases_return_pass(gen_list_account_aliases_paginator):
 
 def test_list_account_aliases_return_fail(gen_list_ssh_public_keys_paginator):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -251,7 +251,7 @@ def test_list_attached_group_policies_return_pass(
 
 def test_list_attached_group_policies_return_fail(gen_list_user_policies_paginator):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -300,7 +300,7 @@ def test_list_attached_role_policies_return_fail(
     gen_list_server_certificates_paginator,
 ):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -347,7 +347,7 @@ def test_list_attached_user_policies_return_pass(
 
 def test_list_attached_user_policies_return_fail(gen_list_roles_paginator):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -390,7 +390,7 @@ def test_list_entities_for_policy_return_pass(gen_list_entities_for_policy_pagin
 
 def test_list_entities_for_policy_return_fail(gen_get_group_paginator):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -433,7 +433,7 @@ def test_list_group_policies_return_pass(gen_list_group_policies_paginator):
 
 def test_list_group_policies_return_fail(gen_get_group_paginator):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -476,7 +476,7 @@ def test_list_groups_return_pass(gen_list_groups_paginator):
 
 def test_list_groups_return_fail(gen_list_account_aliases_paginator):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -519,7 +519,7 @@ def test_list_groups_for_user_return_pass(gen_list_groups_for_user_paginator):
 
 def test_list_groups_for_user_return_fail(gen_list_policies_paginator):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -562,7 +562,7 @@ def test_list_instance_profiles_return_pass(gen_list_instance_profiles_paginator
 
 def test_list_instance_profiles_return_fail(gen_list_groups_for_user_paginator):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -609,7 +609,7 @@ def test_list_instance_profiles_for_role_return_pass(
 
 def test_list_instance_profiles_for_role_return_fail(gen_list_group_policies_paginator):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -652,7 +652,7 @@ def test_list_mfa_devices_return_pass(gen_list_mfa_devices_paginator):
 
 def test_list_mfa_devices_return_fail(gen_list_instance_profiles_for_role_paginator):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -695,7 +695,7 @@ def test_list_policies_return_pass(gen_list_policies_paginator):
 
 def test_list_policies_return_fail(gen_list_role_policies_paginator):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -738,7 +738,7 @@ def test_list_policy_versions_return_pass(gen_list_policy_versions_paginator):
 
 def test_list_policy_versions_return_fail(gen_list_account_aliases_paginator):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -781,7 +781,7 @@ def test_list_role_policies_return_pass(gen_list_role_policies_paginator):
 
 def test_list_role_policies_return_fail(gen_list_policies_paginator):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -824,7 +824,7 @@ def test_list_roles_return_pass(gen_list_roles_paginator):
 
 def test_list_roles_return_fail(gen_list_group_policies_paginator):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -867,7 +867,7 @@ def test_list_server_certificates_return_pass(gen_list_server_certificates_pagin
 
 def test_list_server_certificates_return_fail(gen_list_user_policies_paginator):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -910,7 +910,7 @@ def test_list_signing_certificates_return_pass(gen_list_signing_certificates_pag
 
 def test_list_signing_certificates_return_fail(gen_list_group_policies_paginator):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -953,7 +953,7 @@ def test_list_ssh_public_keys_return_pass(gen_list_ssh_public_keys_paginator):
 
 def test_list_ssh_public_keys_return_fail(gen_list_users_paginator):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -996,7 +996,7 @@ def test_list_user_policies_return_pass(gen_list_user_policies_paginator):
 
 def test_list_user_policies_return_fail(gen_list_groups_paginator):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -1039,7 +1039,7 @@ def test_list_users_return_pass(gen_list_users_paginator):
 
 def test_list_users_return_fail(gen_get_group_paginator):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -1082,7 +1082,7 @@ def test_list_virtual_mfa_devices_return_pass(gen_list_virtual_mfa_devices_pagin
 
 def test_list_virtual_mfa_devices_return_fail(gen_list_policy_versions_paginator):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -1125,7 +1125,7 @@ def test_simulate_custom_policy_return_pass(gen_simulate_custom_policy_paginator
 
 def test_simulate_custom_policy_return_fail(gen_list_instance_profiles_paginator):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -1168,7 +1168,7 @@ def test_simulate_principal_policy_return_pass(gen_simulate_principal_policy_pag
 
 def test_simulate_principal_policy_return_fail(gen_list_policy_versions_paginator):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -1211,7 +1211,7 @@ def test_list_user_tags_return_pass(gen_list_user_tags_paginator):
 
 def test_list_user_tags_return_fail(gen_get_account_authorization_details_paginator):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype

--- a/tests/iam/test_iam_resources.py
+++ b/tests/iam/test_iam_resources.py
@@ -24,7 +24,7 @@ from bearboto3.iam import (
 )
 from beartype import beartype
 from beartype.roar import (
-    BeartypeCallHintPepParamException,
+    BeartypeCallHintParamViolation,
     BeartypeCallHintReturnViolation,
     BeartypeDecorHintPep484585Exception,
 )
@@ -44,7 +44,7 @@ def test_access_key_arg_pass(gen_access_key):
 
 
 def test_access_key_arg_fail(gen_role):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: AccessKey):
@@ -87,7 +87,7 @@ def test_access_key_pair_arg_pass(gen_access_key_pair):
 
 
 def test_access_key_pair_arg_fail(gen_policy_version):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: AccessKeyPair):
@@ -130,7 +130,7 @@ def test_account_password_policy_arg_pass(gen_account_password_policy):
 
 
 def test_account_password_policy_arg_fail(gen_mfa_device):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: AccountPasswordPolicy):
@@ -173,7 +173,7 @@ def test_account_summary_arg_pass(gen_account_summary):
 
 
 def test_account_summary_arg_fail(gen_role):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: AccountSummary):
@@ -216,7 +216,7 @@ def test_assume_role_policy_arg_pass(gen_assume_role_policy):
 
 
 def test_assume_role_policy_arg_fail(gen_signing_certificate):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: AssumeRolePolicy):
@@ -259,7 +259,7 @@ def test_current_user_arg_pass(gen_current_user):
 
 
 def test_current_user_arg_fail(gen_mfa_device):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: CurrentUser):
@@ -302,7 +302,7 @@ def test_group_arg_pass(gen_group):
 
 
 def test_group_arg_fail(gen_account_summary):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: Group):
@@ -345,7 +345,7 @@ def test_group_policy_arg_pass(gen_group_policy):
 
 
 def test_group_policy_arg_fail(gen_access_key_pair):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: GroupPolicy):
@@ -388,7 +388,7 @@ def test_instance_profile_arg_pass(gen_instance_profile):
 
 
 def test_instance_profile_arg_fail(gen_current_user):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: InstanceProfile):
@@ -431,7 +431,7 @@ def test_login_profile_arg_pass(gen_login_profile):
 
 
 def test_login_profile_arg_fail(gen_role_policy):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: LoginProfile):
@@ -474,7 +474,7 @@ def test_mfa_device_arg_pass(gen_mfa_device):
 
 
 def test_mfa_device_arg_fail(gen_server_certificate):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: MfaDevice):
@@ -517,7 +517,7 @@ def test_policy_arg_pass(gen_policy):
 
 
 def test_policy_arg_fail(gen_role):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: Policy):
@@ -560,7 +560,7 @@ def test_policy_version_arg_pass(gen_policy_version):
 
 
 def test_policy_version_arg_fail(gen_group):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: PolicyVersion):
@@ -603,7 +603,7 @@ def test_role_arg_pass(gen_role):
 
 
 def test_role_arg_fail(gen_account_summary):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: Role):
@@ -646,7 +646,7 @@ def test_role_policy_arg_pass(gen_role_policy):
 
 
 def test_role_policy_arg_fail(gen_group):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: RolePolicy):
@@ -689,7 +689,7 @@ def test_saml_provider_arg_pass(gen_saml_provider):
 
 
 def test_saml_provider_arg_fail(gen_mfa_device):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: SamlProvider):
@@ -732,7 +732,7 @@ def test_server_certificate_arg_pass(gen_server_certificate):
 
 
 def test_server_certificate_arg_fail(gen_saml_provider):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: ServerCertificate):
@@ -775,7 +775,7 @@ def test_signing_certificate_arg_pass(gen_signing_certificate):
 
 
 def test_signing_certificate_arg_fail(gen_saml_provider):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: SigningCertificate):
@@ -818,7 +818,7 @@ def test_user_arg_pass(gen_user):
 
 
 def test_user_arg_fail(gen_role_policy):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: User):
@@ -861,7 +861,7 @@ def test_user_policy_arg_pass(gen_user_policy):
 
 
 def test_user_policy_arg_fail(gen_account_summary):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: UserPolicy):
@@ -904,7 +904,7 @@ def test_virtual_mfa_device_arg_pass(gen_virtual_mfa_device):
 
 
 def test_virtual_mfa_device_arg_fail(gen_role):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: VirtualMfaDevice):

--- a/tests/iam/test_iam_resources.py
+++ b/tests/iam/test_iam_resources.py
@@ -25,7 +25,7 @@ from bearboto3.iam import (
 from beartype import beartype
 from beartype.roar import (
     BeartypeCallHintPepParamException,
-    BeartypeCallHintPepReturnException,
+    BeartypeCallHintReturnViolation,
     BeartypeDecorHintPep484585Exception,
 )
 
@@ -63,7 +63,7 @@ def test_access_key_return_pass(gen_access_key):
 
 def test_access_key_return_fail(gen_role):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -106,7 +106,7 @@ def test_access_key_pair_return_pass(gen_access_key_pair):
 
 def test_access_key_pair_return_fail(gen_policy_version):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -149,7 +149,7 @@ def test_account_password_policy_return_pass(gen_account_password_policy):
 
 def test_account_password_policy_return_fail(gen_mfa_device):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -192,7 +192,7 @@ def test_account_summary_return_pass(gen_account_summary):
 
 def test_account_summary_return_fail(gen_role):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -235,7 +235,7 @@ def test_assume_role_policy_return_pass(gen_assume_role_policy):
 
 def test_assume_role_policy_return_fail(gen_signing_certificate):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -278,7 +278,7 @@ def test_current_user_return_pass(gen_current_user):
 
 def test_current_user_return_fail(gen_mfa_device):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -321,7 +321,7 @@ def test_group_return_pass(gen_group):
 
 def test_group_return_fail(gen_account_summary):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -364,7 +364,7 @@ def test_group_policy_return_pass(gen_group_policy):
 
 def test_group_policy_return_fail(gen_access_key_pair):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -407,7 +407,7 @@ def test_instance_profile_return_pass(gen_instance_profile):
 
 def test_instance_profile_return_fail(gen_current_user):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -450,7 +450,7 @@ def test_login_profile_return_pass(gen_login_profile):
 
 def test_login_profile_return_fail(gen_role_policy):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -493,7 +493,7 @@ def test_mfa_device_return_pass(gen_mfa_device):
 
 def test_mfa_device_return_fail(gen_server_certificate):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -536,7 +536,7 @@ def test_policy_return_pass(gen_policy):
 
 def test_policy_return_fail(gen_role):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -579,7 +579,7 @@ def test_policy_version_return_pass(gen_policy_version):
 
 def test_policy_version_return_fail(gen_group):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -622,7 +622,7 @@ def test_role_return_pass(gen_role):
 
 def test_role_return_fail(gen_account_summary):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -665,7 +665,7 @@ def test_role_policy_return_pass(gen_role_policy):
 
 def test_role_policy_return_fail(gen_group):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -708,7 +708,7 @@ def test_saml_provider_return_pass(gen_saml_provider):
 
 def test_saml_provider_return_fail(gen_mfa_device):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -751,7 +751,7 @@ def test_server_certificate_return_pass(gen_server_certificate):
 
 def test_server_certificate_return_fail(gen_saml_provider):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -794,7 +794,7 @@ def test_signing_certificate_return_pass(gen_signing_certificate):
 
 def test_signing_certificate_return_fail(gen_saml_provider):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -837,7 +837,7 @@ def test_user_return_pass(gen_user):
 
 def test_user_return_fail(gen_role_policy):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -880,7 +880,7 @@ def test_user_policy_return_pass(gen_user_policy):
 
 def test_user_policy_return_fail(gen_account_summary):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -923,7 +923,7 @@ def test_virtual_mfa_device_return_pass(gen_virtual_mfa_device):
 
 def test_virtual_mfa_device_return_fail(gen_role):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype

--- a/tests/iam/test_iam_waiters.py
+++ b/tests/iam/test_iam_waiters.py
@@ -7,7 +7,7 @@ from bearboto3.iam import (
 )
 from beartype import beartype
 from beartype.roar import (
-    BeartypeCallHintPepParamException,
+    BeartypeCallHintParamViolation,
     BeartypeCallHintReturnViolation,
     BeartypeDecorHintPep484585Exception,
 )
@@ -27,7 +27,7 @@ def test_instance_profile_exists_arg_pass(gen_instance_profile_exists_waiter):
 
 
 def test_instance_profile_exists_arg_fail(gen_user_exists_waiter):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: InstanceProfileExistsWaiter):
@@ -70,7 +70,7 @@ def test_user_exists_arg_pass(gen_user_exists_waiter):
 
 
 def test_user_exists_arg_fail(gen_instance_profile_exists_waiter):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: UserExistsWaiter):
@@ -113,7 +113,7 @@ def test_role_exists_arg_pass(gen_role_exists_waiter):
 
 
 def test_role_exists_arg_fail(gen_user_exists_waiter):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: RoleExistsWaiter):
@@ -156,7 +156,7 @@ def test_policy_exists_arg_pass(gen_policy_exists_waiter):
 
 
 def test_policy_exists_arg_fail(gen_role_exists_waiter):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: PolicyExistsWaiter):

--- a/tests/iam/test_iam_waiters.py
+++ b/tests/iam/test_iam_waiters.py
@@ -8,7 +8,7 @@ from bearboto3.iam import (
 from beartype import beartype
 from beartype.roar import (
     BeartypeCallHintPepParamException,
-    BeartypeCallHintPepReturnException,
+    BeartypeCallHintReturnViolation,
     BeartypeDecorHintPep484585Exception,
 )
 
@@ -46,7 +46,7 @@ def test_instance_profile_exists_return_pass(gen_instance_profile_exists_waiter)
 
 def test_instance_profile_exists_return_fail(gen_user_exists_waiter):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -89,7 +89,7 @@ def test_user_exists_return_pass(gen_user_exists_waiter):
 
 def test_user_exists_return_fail(gen_instance_profile_exists_waiter):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -132,7 +132,7 @@ def test_role_exists_return_pass(gen_role_exists_waiter):
 
 def test_role_exists_return_fail(gen_user_exists_waiter):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -175,7 +175,7 @@ def test_policy_exists_return_pass(gen_policy_exists_waiter):
 
 def test_policy_exists_return_fail(gen_role_exists_waiter):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype

--- a/tests/lambda_/test_lambda_clients.py
+++ b/tests/lambda_/test_lambda_clients.py
@@ -4,7 +4,7 @@ from bearboto3.lambda_ import (
 )
 from beartype import beartype
 from beartype.roar import (
-    BeartypeCallHintPepParamException,
+    BeartypeCallHintParamViolation,
     BeartypeCallHintReturnViolation,
     BeartypeDecorHintPep484585Exception,
 )
@@ -24,7 +24,7 @@ def test_lambda_client_arg_pass(gen_lambda_client):
 
 
 def test_lambda_client_arg_fail(gen_s3_client):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: LambdaClient):

--- a/tests/lambda_/test_lambda_clients.py
+++ b/tests/lambda_/test_lambda_clients.py
@@ -5,7 +5,7 @@ from bearboto3.lambda_ import (
 from beartype import beartype
 from beartype.roar import (
     BeartypeCallHintPepParamException,
-    BeartypeCallHintPepReturnException,
+    BeartypeCallHintReturnViolation,
     BeartypeDecorHintPep484585Exception,
 )
 
@@ -43,7 +43,7 @@ def test_lambda_client_return_pass(gen_lambda_client):
 
 def test_lambda_client_return_fail(gen_s3_client):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype

--- a/tests/lambda_/test_lambda_paginators.py
+++ b/tests/lambda_/test_lambda_paginators.py
@@ -13,7 +13,7 @@ from bearboto3.lambda_ import (
 )
 from beartype import beartype
 from beartype.roar import (
-    BeartypeCallHintPepParamException,
+    BeartypeCallHintParamViolation,
     BeartypeCallHintReturnViolation,
     BeartypeDecorHintPep484585Exception,
 )
@@ -35,7 +35,7 @@ def test_list_event_source_mappings_arg_pass(gen_list_event_source_mappings_pagi
 def test_list_event_source_mappings_arg_fail(
     gen_list_functions_by_code_signing_config_paginator,
 ):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: ListEventSourceMappingsPaginator):
@@ -82,7 +82,7 @@ def test_list_functions_arg_pass(gen_list_functions_paginator):
 
 
 def test_list_functions_arg_fail(gen_list_code_signing_configs_paginator):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: ListFunctionsPaginator):
@@ -125,7 +125,7 @@ def test_list_aliases_arg_pass(gen_list_aliases_paginator):
 
 
 def test_list_aliases_arg_fail(gen_list_provisioned_concurrency_configs_paginator):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: ListAliasesPaginator):
@@ -168,7 +168,7 @@ def test_list_layer_versions_arg_pass(gen_list_layer_versions_paginator):
 
 
 def test_list_layer_versions_arg_fail(gen_list_aliases_paginator):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: ListLayerVersionsPaginator):
@@ -211,7 +211,7 @@ def test_list_layers_arg_pass(gen_list_layers_paginator):
 
 
 def test_list_layers_arg_fail(gen_list_code_signing_configs_paginator):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: ListLayersPaginator):
@@ -256,7 +256,7 @@ def test_list_versions_by_function_arg_pass(gen_list_versions_by_function_pagina
 def test_list_versions_by_function_arg_fail(
     gen_list_function_event_invoke_configs_paginator,
 ):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: ListVersionsByFunctionPaginator):
@@ -305,7 +305,7 @@ def test_list_function_event_invoke_configs_arg_pass(
 def test_list_function_event_invoke_configs_arg_fail(
     gen_list_code_signing_configs_paginator,
 ):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: ListFunctionEventInvokeConfigsPaginator):
@@ -356,7 +356,7 @@ def test_list_provisioned_concurrency_configs_arg_pass(
 def test_list_provisioned_concurrency_configs_arg_fail(
     gen_list_function_event_invoke_configs_paginator,
 ):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: ListProvisionedConcurrencyConfigsPaginator):
@@ -403,7 +403,7 @@ def test_list_code_signing_configs_arg_pass(gen_list_code_signing_configs_pagina
 
 
 def test_list_code_signing_configs_arg_fail(gen_list_functions_paginator):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: ListCodeSigningConfigsPaginator):
@@ -448,7 +448,7 @@ def test_list_functions_by_code_signing_config_arg_pass(
 
 
 def test_list_functions_by_code_signing_config_arg_fail(gen_list_functions_paginator):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: ListFunctionsByCodeSigningConfigPaginator):

--- a/tests/lambda_/test_lambda_paginators.py
+++ b/tests/lambda_/test_lambda_paginators.py
@@ -14,7 +14,7 @@ from bearboto3.lambda_ import (
 from beartype import beartype
 from beartype.roar import (
     BeartypeCallHintPepParamException,
-    BeartypeCallHintPepReturnException,
+    BeartypeCallHintReturnViolation,
     BeartypeDecorHintPep484585Exception,
 )
 
@@ -58,7 +58,7 @@ def test_list_event_source_mappings_return_fail(
     gen_list_functions_by_code_signing_config_paginator,
 ):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -101,7 +101,7 @@ def test_list_functions_return_pass(gen_list_functions_paginator):
 
 def test_list_functions_return_fail(gen_list_code_signing_configs_paginator):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -144,7 +144,7 @@ def test_list_aliases_return_pass(gen_list_aliases_paginator):
 
 def test_list_aliases_return_fail(gen_list_provisioned_concurrency_configs_paginator):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -187,7 +187,7 @@ def test_list_layer_versions_return_pass(gen_list_layer_versions_paginator):
 
 def test_list_layer_versions_return_fail(gen_list_aliases_paginator):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -230,7 +230,7 @@ def test_list_layers_return_pass(gen_list_layers_paginator):
 
 def test_list_layers_return_fail(gen_list_code_signing_configs_paginator):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -277,7 +277,7 @@ def test_list_versions_by_function_return_fail(
     gen_list_function_event_invoke_configs_paginator,
 ):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -328,7 +328,7 @@ def test_list_function_event_invoke_configs_return_fail(
     gen_list_code_signing_configs_paginator,
 ):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -379,7 +379,7 @@ def test_list_provisioned_concurrency_configs_return_fail(
     gen_list_function_event_invoke_configs_paginator,
 ):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -422,7 +422,7 @@ def test_list_code_signing_configs_return_pass(gen_list_code_signing_configs_pag
 
 def test_list_code_signing_configs_return_fail(gen_list_functions_paginator):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -471,7 +471,7 @@ def test_list_functions_by_code_signing_config_return_fail(
     gen_list_functions_paginator,
 ):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype

--- a/tests/lambda_/test_lambda_waiters.py
+++ b/tests/lambda_/test_lambda_waiters.py
@@ -6,7 +6,7 @@ from bearboto3.lambda_ import (
 )
 from beartype import beartype
 from beartype.roar import (
-    BeartypeCallHintPepParamException,
+    BeartypeCallHintParamViolation,
     BeartypeCallHintReturnViolation,
     BeartypeDecorHintPep484585Exception,
 )
@@ -26,7 +26,7 @@ def test_function_exists_arg_pass(gen_function_exists_waiter):
 
 
 def test_function_exists_arg_fail(gen_function_updated_waiter):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: FunctionExistsWaiter):
@@ -69,7 +69,7 @@ def test_function_active_arg_pass(gen_function_active_waiter):
 
 
 def test_function_active_arg_fail(gen_function_exists_waiter):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: FunctionActiveWaiter):
@@ -112,7 +112,7 @@ def test_function_updated_arg_pass(gen_function_updated_waiter):
 
 
 def test_function_updated_arg_fail(gen_function_exists_waiter):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: FunctionUpdatedWaiter):

--- a/tests/lambda_/test_lambda_waiters.py
+++ b/tests/lambda_/test_lambda_waiters.py
@@ -7,7 +7,7 @@ from bearboto3.lambda_ import (
 from beartype import beartype
 from beartype.roar import (
     BeartypeCallHintPepParamException,
-    BeartypeCallHintPepReturnException,
+    BeartypeCallHintReturnViolation,
     BeartypeDecorHintPep484585Exception,
 )
 
@@ -45,7 +45,7 @@ def test_function_exists_return_pass(gen_function_exists_waiter):
 
 def test_function_exists_return_fail(gen_function_updated_waiter):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -88,7 +88,7 @@ def test_function_active_return_pass(gen_function_active_waiter):
 
 def test_function_active_return_fail(gen_function_exists_waiter):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -131,7 +131,7 @@ def test_function_updated_return_pass(gen_function_updated_waiter):
 
 def test_function_updated_return_fail(gen_function_exists_waiter):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype

--- a/tests/s3/test_s3_clients.py
+++ b/tests/s3/test_s3_clients.py
@@ -5,7 +5,7 @@ from bearboto3.s3 import (
 )
 from beartype import beartype
 from beartype.roar import (
-    BeartypeCallHintPepParamException,
+    BeartypeCallHintParamViolation,
     BeartypeCallHintReturnViolation,
     BeartypeDecorHintPep484585Exception,
 )
@@ -25,7 +25,7 @@ def test_s3_client_arg_pass(gen_s3_client):
 
 
 def test_s3_client_arg_fail(gen_ec2_client):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: S3Client):
@@ -68,7 +68,7 @@ def test_s3_resource_arg_pass(gen_s3_resource):
 
 
 def test_s3_resource_arg_fail(gen_ec2_resource):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: S3ServiceResource):

--- a/tests/s3/test_s3_clients.py
+++ b/tests/s3/test_s3_clients.py
@@ -6,7 +6,7 @@ from bearboto3.s3 import (
 from beartype import beartype
 from beartype.roar import (
     BeartypeCallHintPepParamException,
-    BeartypeCallHintPepReturnException,
+    BeartypeCallHintReturnViolation,
     BeartypeDecorHintPep484585Exception,
 )
 
@@ -44,7 +44,7 @@ def test_s3_client_return_pass(gen_s3_client):
 
 def test_s3_client_return_fail(gen_ec2_client):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -87,7 +87,7 @@ def test_s3_resource_return_pass(gen_s3_resource):
 
 def test_s3_resource_return_fail(gen_ec2_resource):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype

--- a/tests/s3/test_s3_collections.py
+++ b/tests/s3/test_s3_collections.py
@@ -9,7 +9,7 @@ from bearboto3.s3 import (
 from beartype import beartype
 from beartype.roar import (
     BeartypeCallHintPepParamException,
-    BeartypeCallHintPepReturnException,
+    BeartypeCallHintReturnViolation,
     BeartypeDecorHintPep484585Exception,
 )
 
@@ -47,7 +47,7 @@ def test_buckets_return_pass(gen_service_resource_buckets_collection):
 
 def test_buckets_return_fail(gen_bucket_objects_collection):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -90,7 +90,7 @@ def test_multipart_uploads_return_pass(gen_bucket_multipart_uploads_collection):
 
 def test_multipart_uploads_return_fail(gen_bucket_object_versions_collection):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -133,7 +133,7 @@ def test_object_versions_return_pass(gen_bucket_object_versions_collection):
 
 def test_object_versions_return_fail(gen_bucket_objects_collection):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -176,7 +176,7 @@ def test_objects_return_pass(gen_bucket_objects_collection):
 
 def test_objects_return_fail(gen_service_resource_buckets_collection):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -219,7 +219,7 @@ def test_parts_return_pass(gen_multipart_upload_parts_collection):
 
 def test_parts_return_fail(gen_bucket_object_versions_collection):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype

--- a/tests/s3/test_s3_collections.py
+++ b/tests/s3/test_s3_collections.py
@@ -8,7 +8,7 @@ from bearboto3.s3 import (
 )
 from beartype import beartype
 from beartype.roar import (
-    BeartypeCallHintPepParamException,
+    BeartypeCallHintParamViolation,
     BeartypeCallHintReturnViolation,
     BeartypeDecorHintPep484585Exception,
 )
@@ -28,7 +28,7 @@ def test_buckets_arg_pass(gen_service_resource_buckets_collection):
 
 
 def test_buckets_arg_fail(gen_bucket_objects_collection):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: ServiceResourceBucketsCollection):
@@ -71,7 +71,7 @@ def test_multipart_uploads_arg_pass(gen_bucket_multipart_uploads_collection):
 
 
 def test_multipart_uploads_arg_fail(gen_bucket_object_versions_collection):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: BucketMultipartUploadsCollection):
@@ -114,7 +114,7 @@ def test_object_versions_arg_pass(gen_bucket_object_versions_collection):
 
 
 def test_object_versions_arg_fail(gen_bucket_objects_collection):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: BucketObjectVersionsCollection):
@@ -157,7 +157,7 @@ def test_objects_arg_pass(gen_bucket_objects_collection):
 
 
 def test_objects_arg_fail(gen_service_resource_buckets_collection):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: BucketObjectsCollection):
@@ -200,7 +200,7 @@ def test_parts_arg_pass(gen_multipart_upload_parts_collection):
 
 
 def test_parts_arg_fail(gen_bucket_object_versions_collection):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: MultipartUploadPartsCollection):

--- a/tests/s3/test_s3_paginators.py
+++ b/tests/s3/test_s3_paginators.py
@@ -8,7 +8,7 @@ from bearboto3.s3 import (
 )
 from beartype import beartype
 from beartype.roar import (
-    BeartypeCallHintPepParamException,
+    BeartypeCallHintParamViolation,
     BeartypeCallHintReturnViolation,
     BeartypeDecorHintPep484585Exception,
 )
@@ -28,7 +28,7 @@ def test_list_multipart_uploads_arg_pass(gen_list_multipart_uploads_paginator):
 
 
 def test_list_multipart_uploads_arg_fail(gen_list_objects_v2_paginator):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: ListMultipartUploadsPaginator):
@@ -71,7 +71,7 @@ def test_list_object_versions_arg_pass(gen_list_object_versions_paginator):
 
 
 def test_list_object_versions_arg_fail(gen_list_objects_v2_paginator):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: ListObjectVersionsPaginator):
@@ -114,7 +114,7 @@ def test_list_objects_arg_pass(gen_list_objects_paginator):
 
 
 def test_list_objects_arg_fail(gen_list_multipart_uploads_paginator):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: ListObjectsPaginator):
@@ -157,7 +157,7 @@ def test_list_objects_v2_arg_pass(gen_list_objects_v2_paginator):
 
 
 def test_list_objects_v2_arg_fail(gen_list_object_versions_paginator):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: ListObjectsV2Paginator):
@@ -200,7 +200,7 @@ def test_list_parts_arg_pass(gen_list_parts_paginator):
 
 
 def test_list_parts_arg_fail(gen_list_object_versions_paginator):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: ListPartsPaginator):

--- a/tests/s3/test_s3_paginators.py
+++ b/tests/s3/test_s3_paginators.py
@@ -9,7 +9,7 @@ from bearboto3.s3 import (
 from beartype import beartype
 from beartype.roar import (
     BeartypeCallHintPepParamException,
-    BeartypeCallHintPepReturnException,
+    BeartypeCallHintReturnViolation,
     BeartypeDecorHintPep484585Exception,
 )
 
@@ -47,7 +47,7 @@ def test_list_multipart_uploads_return_pass(gen_list_multipart_uploads_paginator
 
 def test_list_multipart_uploads_return_fail(gen_list_objects_v2_paginator):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -90,7 +90,7 @@ def test_list_object_versions_return_pass(gen_list_object_versions_paginator):
 
 def test_list_object_versions_return_fail(gen_list_objects_v2_paginator):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -133,7 +133,7 @@ def test_list_objects_return_pass(gen_list_objects_paginator):
 
 def test_list_objects_return_fail(gen_list_multipart_uploads_paginator):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -176,7 +176,7 @@ def test_list_objects_v2_return_pass(gen_list_objects_v2_paginator):
 
 def test_list_objects_v2_return_fail(gen_list_object_versions_paginator):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -219,7 +219,7 @@ def test_list_parts_return_pass(gen_list_parts_paginator):
 
 def test_list_parts_return_fail(gen_list_object_versions_paginator):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype

--- a/tests/s3/test_s3_resources.py
+++ b/tests/s3/test_s3_resources.py
@@ -22,7 +22,7 @@ from bearboto3.s3 import (
 from beartype import beartype
 from beartype.roar import (
     BeartypeCallHintPepParamException,
-    BeartypeCallHintPepReturnException,
+    BeartypeCallHintReturnViolation,
     BeartypeDecorHintPep484585Exception,
 )
 
@@ -60,7 +60,7 @@ def test_bucket_return_pass(gen_bucket):
 
 def test_bucket_return_fail(gen_bucket_versioning):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -103,7 +103,7 @@ def test_bucket_acl_return_pass(gen_bucket_acl):
 
 def test_bucket_acl_return_fail(gen_bucket_lifecycle_configuration):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -146,7 +146,7 @@ def test_bucket_cors_return_pass(gen_bucket_cors):
 
 def test_bucket_cors_return_fail(gen_multipart_upload):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -189,7 +189,7 @@ def test_bucket_lifecycle_return_pass(gen_bucket_lifecycle):
 
 def test_bucket_lifecycle_return_fail(gen_bucket_logging):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -232,7 +232,7 @@ def test_bucket_lifecycle_configuration_return_pass(gen_bucket_lifecycle_configu
 
 def test_bucket_lifecycle_configuration_return_fail(gen_bucket_notification):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -275,7 +275,7 @@ def test_bucket_logging_return_pass(gen_bucket_logging):
 
 def test_bucket_logging_return_fail(gen_object_acl):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -318,7 +318,7 @@ def test_bucket_notification_return_pass(gen_bucket_notification):
 
 def test_bucket_notification_return_fail(gen_bucket_tagging):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -361,7 +361,7 @@ def test_bucket_policy_return_pass(gen_bucket_policy):
 
 def test_bucket_policy_return_fail(gen_bucket):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -404,7 +404,7 @@ def test_bucket_request_payment_return_pass(gen_bucket_request_payment):
 
 def test_bucket_request_payment_return_fail(gen_bucket_cors):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -447,7 +447,7 @@ def test_bucket_tagging_return_pass(gen_bucket_tagging):
 
 def test_bucket_tagging_return_fail(gen_multipart_upload_part):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -490,7 +490,7 @@ def test_bucket_versioning_return_pass(gen_bucket_versioning):
 
 def test_bucket_versioning_return_fail(gen_object_summary):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -533,7 +533,7 @@ def test_bucket_website_return_pass(gen_bucket_website):
 
 def test_bucket_website_return_fail(gen_bucket_logging):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -576,7 +576,7 @@ def test_multipart_upload_return_pass(gen_multipart_upload):
 
 def test_multipart_upload_return_fail(gen_bucket_logging):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -619,7 +619,7 @@ def test_multipart_upload_part_return_pass(gen_multipart_upload_part):
 
 def test_multipart_upload_part_return_fail(gen_bucket_cors):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -662,7 +662,7 @@ def test_object_return_pass(gen_object):
 
 def test_object_return_fail(gen_bucket_request_payment):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -705,7 +705,7 @@ def test_object_acl_return_pass(gen_object_acl):
 
 def test_object_acl_return_fail(gen_object_summary):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -748,7 +748,7 @@ def test_object_summary_return_pass(gen_object_summary):
 
 def test_object_summary_return_fail(gen_object_acl):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -791,7 +791,7 @@ def test_object_version_return_pass(gen_object_version):
 
 def test_object_version_return_fail(gen_bucket_request_payment):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype

--- a/tests/s3/test_s3_resources.py
+++ b/tests/s3/test_s3_resources.py
@@ -21,7 +21,7 @@ from bearboto3.s3 import (
 )
 from beartype import beartype
 from beartype.roar import (
-    BeartypeCallHintPepParamException,
+    BeartypeCallHintParamViolation,
     BeartypeCallHintReturnViolation,
     BeartypeDecorHintPep484585Exception,
 )
@@ -41,7 +41,7 @@ def test_bucket_arg_pass(gen_bucket):
 
 
 def test_bucket_arg_fail(gen_bucket_versioning):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: Bucket):
@@ -84,7 +84,7 @@ def test_bucket_acl_arg_pass(gen_bucket_acl):
 
 
 def test_bucket_acl_arg_fail(gen_bucket_lifecycle_configuration):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: BucketAcl):
@@ -127,7 +127,7 @@ def test_bucket_cors_arg_pass(gen_bucket_cors):
 
 
 def test_bucket_cors_arg_fail(gen_multipart_upload):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: BucketCors):
@@ -170,7 +170,7 @@ def test_bucket_lifecycle_arg_pass(gen_bucket_lifecycle):
 
 
 def test_bucket_lifecycle_arg_fail(gen_bucket_logging):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: BucketLifecycle):
@@ -213,7 +213,7 @@ def test_bucket_lifecycle_configuration_arg_pass(gen_bucket_lifecycle_configurat
 
 
 def test_bucket_lifecycle_configuration_arg_fail(gen_bucket_notification):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: BucketLifecycleConfiguration):
@@ -256,7 +256,7 @@ def test_bucket_logging_arg_pass(gen_bucket_logging):
 
 
 def test_bucket_logging_arg_fail(gen_object_acl):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: BucketLogging):
@@ -299,7 +299,7 @@ def test_bucket_notification_arg_pass(gen_bucket_notification):
 
 
 def test_bucket_notification_arg_fail(gen_bucket_tagging):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: BucketNotification):
@@ -342,7 +342,7 @@ def test_bucket_policy_arg_pass(gen_bucket_policy):
 
 
 def test_bucket_policy_arg_fail(gen_bucket):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: BucketPolicy):
@@ -385,7 +385,7 @@ def test_bucket_request_payment_arg_pass(gen_bucket_request_payment):
 
 
 def test_bucket_request_payment_arg_fail(gen_bucket_cors):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: BucketRequestPayment):
@@ -428,7 +428,7 @@ def test_bucket_tagging_arg_pass(gen_bucket_tagging):
 
 
 def test_bucket_tagging_arg_fail(gen_multipart_upload_part):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: BucketTagging):
@@ -471,7 +471,7 @@ def test_bucket_versioning_arg_pass(gen_bucket_versioning):
 
 
 def test_bucket_versioning_arg_fail(gen_object_summary):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: BucketVersioning):
@@ -514,7 +514,7 @@ def test_bucket_website_arg_pass(gen_bucket_website):
 
 
 def test_bucket_website_arg_fail(gen_bucket_logging):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: BucketWebsite):
@@ -557,7 +557,7 @@ def test_multipart_upload_arg_pass(gen_multipart_upload):
 
 
 def test_multipart_upload_arg_fail(gen_bucket_logging):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: MultipartUpload):
@@ -600,7 +600,7 @@ def test_multipart_upload_part_arg_pass(gen_multipart_upload_part):
 
 
 def test_multipart_upload_part_arg_fail(gen_bucket_cors):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: MultipartUploadPart):
@@ -643,7 +643,7 @@ def test_object_arg_pass(gen_object):
 
 
 def test_object_arg_fail(gen_bucket_request_payment):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: Object):
@@ -686,7 +686,7 @@ def test_object_acl_arg_pass(gen_object_acl):
 
 
 def test_object_acl_arg_fail(gen_object_summary):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: ObjectAcl):
@@ -729,7 +729,7 @@ def test_object_summary_arg_pass(gen_object_summary):
 
 
 def test_object_summary_arg_fail(gen_object_acl):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: ObjectSummary):
@@ -772,7 +772,7 @@ def test_object_version_arg_pass(gen_object_version):
 
 
 def test_object_version_arg_fail(gen_bucket_request_payment):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: ObjectVersion):

--- a/tests/s3/test_s3_waiters.py
+++ b/tests/s3/test_s3_waiters.py
@@ -7,7 +7,7 @@ from bearboto3.s3 import (
 )
 from beartype import beartype
 from beartype.roar import (
-    BeartypeCallHintPepParamException,
+    BeartypeCallHintParamViolation,
     BeartypeCallHintReturnViolation,
     BeartypeDecorHintPep484585Exception,
 )
@@ -27,7 +27,7 @@ def test_bucket_exists_arg_pass(gen_bucket_exists_waiter):
 
 
 def test_bucket_exists_arg_fail(gen_object_exists_waiter):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: BucketExistsWaiter):
@@ -70,7 +70,7 @@ def test_bucket_not_exists_arg_pass(gen_bucket_not_exists_waiter):
 
 
 def test_bucket_not_exists_arg_fail(gen_object_not_exists_waiter):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: BucketNotExistsWaiter):
@@ -113,7 +113,7 @@ def test_object_exists_arg_pass(gen_object_exists_waiter):
 
 
 def test_object_exists_arg_fail(gen_bucket_exists_waiter):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: ObjectExistsWaiter):
@@ -156,7 +156,7 @@ def test_object_not_exists_arg_pass(gen_object_not_exists_waiter):
 
 
 def test_object_not_exists_arg_fail(gen_bucket_not_exists_waiter):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: ObjectNotExistsWaiter):

--- a/tests/s3/test_s3_waiters.py
+++ b/tests/s3/test_s3_waiters.py
@@ -8,7 +8,7 @@ from bearboto3.s3 import (
 from beartype import beartype
 from beartype.roar import (
     BeartypeCallHintPepParamException,
-    BeartypeCallHintPepReturnException,
+    BeartypeCallHintReturnViolation,
     BeartypeDecorHintPep484585Exception,
 )
 
@@ -46,7 +46,7 @@ def test_bucket_exists_return_pass(gen_bucket_exists_waiter):
 
 def test_bucket_exists_return_fail(gen_object_exists_waiter):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -89,7 +89,7 @@ def test_bucket_not_exists_return_pass(gen_bucket_not_exists_waiter):
 
 def test_bucket_not_exists_return_fail(gen_object_not_exists_waiter):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -132,7 +132,7 @@ def test_object_exists_return_pass(gen_object_exists_waiter):
 
 def test_object_exists_return_fail(gen_bucket_exists_waiter):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -175,7 +175,7 @@ def test_object_not_exists_return_pass(gen_object_not_exists_waiter):
 
 def test_object_not_exists_return_fail(gen_bucket_not_exists_waiter):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype

--- a/tests/sns/test_sns_clients.py
+++ b/tests/sns/test_sns_clients.py
@@ -5,7 +5,7 @@ from bearboto3.sns import (
 )
 from beartype import beartype
 from beartype.roar import (
-    BeartypeCallHintPepParamException,
+    BeartypeCallHintParamViolation,
     BeartypeCallHintReturnViolation,
     BeartypeDecorHintPep484585Exception,
 )
@@ -25,7 +25,7 @@ def test_sns_client_arg_pass(gen_sns_client):
 
 
 def test_sns_client_arg_fail(gen_ec2_client):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: SNSClient):
@@ -68,7 +68,7 @@ def test_sns_resource_arg_pass(gen_sns_resource):
 
 
 def test_sns_resource_arg_fail(gen_ec2_resource):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: SNSServiceResource):

--- a/tests/sns/test_sns_clients.py
+++ b/tests/sns/test_sns_clients.py
@@ -6,7 +6,7 @@ from bearboto3.sns import (
 from beartype import beartype
 from beartype.roar import (
     BeartypeCallHintPepParamException,
-    BeartypeCallHintPepReturnException,
+    BeartypeCallHintReturnViolation,
     BeartypeDecorHintPep484585Exception,
 )
 
@@ -44,7 +44,7 @@ def test_sns_client_return_pass(gen_sns_client):
 
 def test_sns_client_return_fail(gen_ec2_client):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -87,7 +87,7 @@ def test_sns_resource_return_pass(gen_sns_resource):
 
 def test_sns_resource_return_fail(gen_ec2_resource):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype

--- a/tests/sns/test_sns_collections.py
+++ b/tests/sns/test_sns_collections.py
@@ -8,7 +8,7 @@ from bearboto3.sns import (
 )
 from beartype import beartype
 from beartype.roar import (
-    BeartypeCallHintPepParamException,
+    BeartypeCallHintParamViolation,
     BeartypeCallHintReturnViolation,
     BeartypeDecorHintPep484585Exception,
 )
@@ -30,7 +30,7 @@ def test_platform_applications_arg_pass(
 
 
 def test_platform_applications_arg_fail(gen_platform_application_endpoints_collection):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: ServiceResourcePlatformApplicationsCollection):
@@ -77,7 +77,7 @@ def test_subscriptions_arg_pass(gen_service_resource_subscriptions_collection):
 
 
 def test_subscriptions_arg_fail(gen_service_resource_platform_applications_collection):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: ServiceResourceSubscriptionsCollection):
@@ -122,7 +122,7 @@ def test_topics_arg_pass(gen_service_resource_topics_collection):
 
 
 def test_topics_arg_fail(gen_platform_application_endpoints_collection):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: ServiceResourceTopicsCollection):
@@ -165,7 +165,7 @@ def test_endpoints_arg_pass(gen_platform_application_endpoints_collection):
 
 
 def test_endpoints_arg_fail(gen_service_resource_subscriptions_collection):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: PlatformApplicationEndpointsCollection):
@@ -208,7 +208,7 @@ def test_subscriptions_arg_pass(gen_topic_subscriptions_collection):
 
 
 def test_subscriptions_arg_fail(gen_service_resource_topics_collection):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: TopicSubscriptionsCollection):

--- a/tests/sns/test_sns_collections.py
+++ b/tests/sns/test_sns_collections.py
@@ -9,7 +9,7 @@ from bearboto3.sns import (
 from beartype import beartype
 from beartype.roar import (
     BeartypeCallHintPepParamException,
-    BeartypeCallHintPepReturnException,
+    BeartypeCallHintReturnViolation,
     BeartypeDecorHintPep484585Exception,
 )
 
@@ -53,7 +53,7 @@ def test_platform_applications_return_fail(
     gen_platform_application_endpoints_collection,
 ):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -98,7 +98,7 @@ def test_subscriptions_return_fail(
     gen_service_resource_platform_applications_collection,
 ):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -141,7 +141,7 @@ def test_topics_return_pass(gen_service_resource_topics_collection):
 
 def test_topics_return_fail(gen_platform_application_endpoints_collection):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -184,7 +184,7 @@ def test_endpoints_return_pass(gen_platform_application_endpoints_collection):
 
 def test_endpoints_return_fail(gen_service_resource_subscriptions_collection):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -227,7 +227,7 @@ def test_subscriptions_return_pass(gen_topic_subscriptions_collection):
 
 def test_subscriptions_return_fail(gen_service_resource_topics_collection):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype

--- a/tests/sns/test_sns_paginators.py
+++ b/tests/sns/test_sns_paginators.py
@@ -11,7 +11,7 @@ from bearboto3.sns import (
 )
 from beartype import beartype
 from beartype.roar import (
-    BeartypeCallHintPepParamException,
+    BeartypeCallHintParamViolation,
     BeartypeCallHintReturnViolation,
     BeartypeDecorHintPep484585Exception,
 )
@@ -33,7 +33,7 @@ def test_list_endpoints_by_platform_application_arg_pass(
 
 
 def test_list_endpoints_by_platform_application_arg_fail(gen_list_topics_paginator):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: ListEndpointsByPlatformApplicationPaginator):
@@ -78,7 +78,7 @@ def test_list_platform_applications_arg_pass(gen_list_platform_applications_pagi
 
 
 def test_list_platform_applications_arg_fail(gen_list_subscriptions_by_topic_paginator):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: ListPlatformApplicationsPaginator):
@@ -125,7 +125,7 @@ def test_list_subscriptions_arg_pass(gen_list_subscriptions_paginator):
 
 
 def test_list_subscriptions_arg_fail(gen_list_platform_applications_paginator):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: ListSubscriptionsPaginator):
@@ -170,7 +170,7 @@ def test_list_subscriptions_by_topic_arg_pass(
 
 
 def test_list_subscriptions_by_topic_arg_fail(gen_list_platform_applications_paginator):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: ListSubscriptionsByTopicPaginator):
@@ -217,7 +217,7 @@ def test_list_topics_arg_pass(gen_list_topics_paginator):
 
 
 def test_list_topics_arg_fail(gen_list_endpoints_by_platform_application_paginator):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: ListTopicsPaginator):
@@ -264,7 +264,7 @@ def test_list_phone_numbers_opted_out_arg_pass(
 def test_list_phone_numbers_opted_out_arg_fail(
     gen_list_platform_applications_paginator,
 ):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: ListPhoneNumbersOptedOutPaginator):
@@ -311,7 +311,7 @@ def test_list_origination_numbers_arg_pass(gen_list_origination_numbers_paginato
 
 
 def test_list_origination_numbers_arg_fail(gen_list_phone_numbers_opted_out_paginator):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: ListOriginationNumbersPaginator):
@@ -358,7 +358,7 @@ def test_list_sms_sandbox_phone_numbers_arg_pass(
 
 
 def test_list_sms_sandbox_phone_numbers_arg_fail(gen_list_topics_paginator):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: ListSMSSandboxPhoneNumbersPaginator):

--- a/tests/sns/test_sns_paginators.py
+++ b/tests/sns/test_sns_paginators.py
@@ -12,7 +12,7 @@ from bearboto3.sns import (
 from beartype import beartype
 from beartype.roar import (
     BeartypeCallHintPepParamException,
-    BeartypeCallHintPepReturnException,
+    BeartypeCallHintReturnViolation,
     BeartypeDecorHintPep484585Exception,
 )
 
@@ -54,7 +54,7 @@ def test_list_endpoints_by_platform_application_return_pass(
 
 def test_list_endpoints_by_platform_application_return_fail(gen_list_topics_paginator):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -101,7 +101,7 @@ def test_list_platform_applications_return_fail(
     gen_list_subscriptions_by_topic_paginator,
 ):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -144,7 +144,7 @@ def test_list_subscriptions_return_pass(gen_list_subscriptions_paginator):
 
 def test_list_subscriptions_return_fail(gen_list_platform_applications_paginator):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -193,7 +193,7 @@ def test_list_subscriptions_by_topic_return_fail(
     gen_list_platform_applications_paginator,
 ):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -236,7 +236,7 @@ def test_list_topics_return_pass(gen_list_topics_paginator):
 
 def test_list_topics_return_fail(gen_list_endpoints_by_platform_application_paginator):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -287,7 +287,7 @@ def test_list_phone_numbers_opted_out_return_fail(
     gen_list_platform_applications_paginator,
 ):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -332,7 +332,7 @@ def test_list_origination_numbers_return_fail(
     gen_list_phone_numbers_opted_out_paginator,
 ):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -379,7 +379,7 @@ def test_list_sms_sandbox_phone_numbers_return_pass(
 
 def test_list_sms_sandbox_phone_numbers_return_fail(gen_list_topics_paginator):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype

--- a/tests/sns/test_sns_resources.py
+++ b/tests/sns/test_sns_resources.py
@@ -7,7 +7,7 @@ from bearboto3.sns import (
 )
 from beartype import beartype
 from beartype.roar import (
-    BeartypeCallHintPepParamException,
+    BeartypeCallHintParamViolation,
     BeartypeCallHintReturnViolation,
     BeartypeDecorHintPep484585Exception,
 )
@@ -27,7 +27,7 @@ def test_platform_application_arg_pass(gen_platform_application):
 
 
 def test_platform_application_arg_fail(gen_subscription):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: PlatformApplication):
@@ -70,7 +70,7 @@ def test_platform_endpoint_arg_pass(gen_platform_endpoint):
 
 
 def test_platform_endpoint_arg_fail(gen_subscription):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: PlatformEndpoint):
@@ -113,7 +113,7 @@ def test_subscription_arg_pass(gen_subscription):
 
 
 def test_subscription_arg_fail(gen_topic):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: Subscription):
@@ -156,7 +156,7 @@ def test_topic_arg_pass(gen_topic):
 
 
 def test_topic_arg_fail(gen_platform_endpoint):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: Topic):

--- a/tests/sns/test_sns_resources.py
+++ b/tests/sns/test_sns_resources.py
@@ -8,7 +8,7 @@ from bearboto3.sns import (
 from beartype import beartype
 from beartype.roar import (
     BeartypeCallHintPepParamException,
-    BeartypeCallHintPepReturnException,
+    BeartypeCallHintReturnViolation,
     BeartypeDecorHintPep484585Exception,
 )
 
@@ -46,7 +46,7 @@ def test_platform_application_return_pass(gen_platform_application):
 
 def test_platform_application_return_fail(gen_subscription):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -89,7 +89,7 @@ def test_platform_endpoint_return_pass(gen_platform_endpoint):
 
 def test_platform_endpoint_return_fail(gen_subscription):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -132,7 +132,7 @@ def test_subscription_return_pass(gen_subscription):
 
 def test_subscription_return_fail(gen_topic):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -175,7 +175,7 @@ def test_topic_return_pass(gen_topic):
 
 def test_topic_return_fail(gen_platform_endpoint):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype

--- a/tests/sqs/test_sqs_clients.py
+++ b/tests/sqs/test_sqs_clients.py
@@ -5,7 +5,7 @@ from bearboto3.sqs import (
 )
 from beartype import beartype
 from beartype.roar import (
-    BeartypeCallHintPepParamException,
+    BeartypeCallHintParamViolation,
     BeartypeCallHintReturnViolation,
     BeartypeDecorHintPep484585Exception,
 )
@@ -25,7 +25,7 @@ def test_sqs_client_arg_pass(gen_sqs_client):
 
 
 def test_sqs_client_arg_fail(gen_s3_client):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: SQSClient):
@@ -68,7 +68,7 @@ def test_sqs_resource_arg_pass(gen_sqs_resource):
 
 
 def test_sqs_resource_arg_fail(gen_s3_resource):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: SQSServiceResource):

--- a/tests/sqs/test_sqs_clients.py
+++ b/tests/sqs/test_sqs_clients.py
@@ -6,7 +6,7 @@ from bearboto3.sqs import (
 from beartype import beartype
 from beartype.roar import (
     BeartypeCallHintPepParamException,
-    BeartypeCallHintPepReturnException,
+    BeartypeCallHintReturnViolation,
     BeartypeDecorHintPep484585Exception,
 )
 
@@ -44,7 +44,7 @@ def test_sqs_client_return_pass(gen_sqs_client):
 
 def test_sqs_client_return_fail(gen_s3_client):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -87,7 +87,7 @@ def test_sqs_resource_return_pass(gen_sqs_resource):
 
 def test_sqs_resource_return_fail(gen_s3_resource):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype

--- a/tests/sqs/test_sqs_collections.py
+++ b/tests/sqs/test_sqs_collections.py
@@ -6,7 +6,7 @@ from bearboto3.sqs import (
 from beartype import beartype
 from beartype.roar import (
     BeartypeCallHintPepParamException,
-    BeartypeCallHintPepReturnException,
+    BeartypeCallHintReturnViolation,
     BeartypeDecorHintPep484585Exception,
 )
 
@@ -44,7 +44,7 @@ def test_queues_return_pass(gen_service_resource_queues_collection):
 
 def test_queues_return_fail(gen_queue_dead_letter_source_queues_collection):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -91,7 +91,7 @@ def test_dead_letter_source_queues_return_pass(
 
 def test_dead_letter_source_queues_return_fail(gen_service_resource_queues_collection):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype

--- a/tests/sqs/test_sqs_collections.py
+++ b/tests/sqs/test_sqs_collections.py
@@ -5,7 +5,7 @@ from bearboto3.sqs import (
 )
 from beartype import beartype
 from beartype.roar import (
-    BeartypeCallHintPepParamException,
+    BeartypeCallHintParamViolation,
     BeartypeCallHintReturnViolation,
     BeartypeDecorHintPep484585Exception,
 )
@@ -25,7 +25,7 @@ def test_queues_arg_pass(gen_service_resource_queues_collection):
 
 
 def test_queues_arg_fail(gen_queue_dead_letter_source_queues_collection):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: ServiceResourceQueuesCollection):
@@ -70,7 +70,7 @@ def test_dead_letter_source_queues_arg_pass(
 
 
 def test_dead_letter_source_queues_arg_fail(gen_service_resource_queues_collection):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: QueueDeadLetterSourceQueuesCollection):

--- a/tests/sqs/test_sqs_paginators.py
+++ b/tests/sqs/test_sqs_paginators.py
@@ -5,7 +5,7 @@ from bearboto3.sqs import (
 )
 from beartype import beartype
 from beartype.roar import (
-    BeartypeCallHintPepParamException,
+    BeartypeCallHintParamViolation,
     BeartypeCallHintReturnViolation,
     BeartypeDecorHintPep484585Exception,
 )
@@ -27,7 +27,7 @@ def test_list_dead_letter_source_queues_arg_pass(
 
 
 def test_list_dead_letter_source_queues_arg_fail(gen_list_queues_paginator):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: ListDeadLetterSourceQueuesPaginator):
@@ -72,7 +72,7 @@ def test_list_queues_arg_pass(gen_list_queues_paginator):
 
 
 def test_list_queues_arg_fail(gen_list_dead_letter_source_queues_paginator):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: ListQueuesPaginator):

--- a/tests/sqs/test_sqs_paginators.py
+++ b/tests/sqs/test_sqs_paginators.py
@@ -6,7 +6,7 @@ from bearboto3.sqs import (
 from beartype import beartype
 from beartype.roar import (
     BeartypeCallHintPepParamException,
-    BeartypeCallHintPepReturnException,
+    BeartypeCallHintReturnViolation,
     BeartypeDecorHintPep484585Exception,
 )
 
@@ -48,7 +48,7 @@ def test_list_dead_letter_source_queues_return_pass(
 
 def test_list_dead_letter_source_queues_return_fail(gen_list_queues_paginator):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -91,7 +91,7 @@ def test_list_queues_return_pass(gen_list_queues_paginator):
 
 def test_list_queues_return_fail(gen_list_dead_letter_source_queues_paginator):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype

--- a/tests/sqs/test_sqs_resources.py
+++ b/tests/sqs/test_sqs_resources.py
@@ -5,7 +5,7 @@ from bearboto3.sqs import (
 )
 from beartype import beartype
 from beartype.roar import (
-    BeartypeCallHintPepParamException,
+    BeartypeCallHintParamViolation,
     BeartypeCallHintReturnViolation,
     BeartypeDecorHintPep484585Exception,
 )
@@ -25,7 +25,7 @@ def test_message_arg_pass(gen_message):
 
 
 def test_message_arg_fail(gen_queue):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: Message):
@@ -68,7 +68,7 @@ def test_queue_arg_pass(gen_queue):
 
 
 def test_queue_arg_fail(gen_message):
-    with pytest.raises(BeartypeCallHintPepParamException):
+    with pytest.raises(BeartypeCallHintParamViolation):
 
         @beartype
         def func(param: Queue):

--- a/tests/sqs/test_sqs_resources.py
+++ b/tests/sqs/test_sqs_resources.py
@@ -6,7 +6,7 @@ from bearboto3.sqs import (
 from beartype import beartype
 from beartype.roar import (
     BeartypeCallHintPepParamException,
-    BeartypeCallHintPepReturnException,
+    BeartypeCallHintReturnViolation,
     BeartypeDecorHintPep484585Exception,
 )
 
@@ -44,7 +44,7 @@ def test_message_return_pass(gen_message):
 
 def test_message_return_fail(gen_queue):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype
@@ -87,7 +87,7 @@ def test_queue_return_pass(gen_queue):
 
 def test_queue_return_fail(gen_message):
     with pytest.raises(
-        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+        (BeartypeCallHintReturnViolation, BeartypeDecorHintPep484585Exception)
     ):
 
         @beartype


### PR DESCRIPTION
From [the latest unit test run](https://github.com/beartype/bearboto3/runs/6638725593?check_suite_focus=true), beartype has deprecated `BeartypeCallHintPepParamException` and `BeartypeCallHintPepReturnException` which are currently used in the unit tests. This PR simply replaces all references with `BeartypeCallHintParamViolation` and `BeartypeCallHintReturnViolation` as suggested in the warning.